### PR TITLE
chore: release v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6](https://github.com/cxreiff/bevy_ratatui_render/compare/v0.5.5...v0.5.6) - 2024-08-15
+
+### Other
+- version bumps, workflow updates
+
 ## [0.5.5](https://github.com/cxreiff/bevy_ratatui_render/compare/v0.5.4...v0.5.5) - 2024-08-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ratatui_render"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "bevy",
  "bevy_ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui_render"
 description = "A bevy plugin for rendering your bevy app to the terminal using ratatui."
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 authors = ["cxreiff <cooper@cxreiff.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `bevy_ratatui_render`: 0.5.5 -> 0.5.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.6](https://github.com/cxreiff/bevy_ratatui_render/compare/v0.5.5...v0.5.6) - 2024-08-15

### Other
- version bumps, workflow updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).