### PR TITLE
chore: release v0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.9](https://github.com/cxreiff/bevy_ratatui_render/compare/v0.5.8...v0.5.9) - 2024-11-26
+
+### Other
+
+- ratatui 0.29, ratatui-image 3.0
+- added linux_dependencies to check workflow
+- update secret name in workflows
+
 ## [0.5.8](https://github.com/cxreiff/bevy_ratatui_render/compare/v0.5.7...v0.5.8) - 2024-10-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ratatui_render"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bevy",
  "bevy_ratatui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,9 +862,9 @@ checksum = "61baa1bdc1f4a7ac2c18217570a7cc04e1cd54d38456e91782f0371c79afe0a8"
 
 [[package]]
 name = "bevy_ratatui"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f74a2a22c1c73b105995e2a86e9d1e2c55586c32f4d90614a37c6ec079ba16"
+checksum = "57dd76a9156b8b51bbd6d3656d1cdecaddeb12d75cfb29fbc72bd3ba233eee89"
 dependencies = [
  "bevy",
  "bitflags 2.6.0",
@@ -1469,7 +1469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -1833,12 +1833,6 @@ name = "dpi"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"
@@ -2446,6 +2440,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "inflections"
@@ -3586,38 +3586,39 @@ checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
 name = "ratatui"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags 2.6.0",
  "cassowary",
  "compact_str",
  "crossterm",
+ "indoc",
  "instability",
  "itertools 0.13.0",
  "lru",
  "paste",
  "strum",
- "strum_macros",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
 name = "ratatui-image"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb525a8d7c50ca224a238ae3bb3caf5ec357292ff91fcac28748a27b66dcacb"
+checksum = "e3a07161c498ddd5066a444a869f27fd97cfc164dbee8c0bdb5ff803b8bb54ce"
 dependencies = [
  "base64 0.21.7",
- "dyn-clone",
  "icy_sixel",
  "image",
  "rand",
  "ratatui",
  "rustix",
+ "thiserror",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -4357,7 +4358,7 @@ checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
  "itertools 0.13.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -4365,6 +4366,12 @@ name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ keywords = ["bevy", "ratatui", "terminal", "tui", "render"]
 bevy = "0.14.2"
 crossterm = "0.28.0"
 crossbeam-channel = "0.5.13"
-ratatui = "0.28.1"
-ratatui-image = "2.0.1"
-bevy_ratatui = "0.6.3"
+ratatui = "0.29.0"
+ratatui-image = "3.0.0"
+bevy_ratatui = "0.6.4"
 
 [profile.dev]
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui_render"
 description = "A bevy plugin for rendering your bevy app to the terminal using ratatui."
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 authors = ["cxreiff <cooper@cxreiff.com>"]
 license = "MIT OR Apache-2.0"

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -13,8 +13,8 @@ pub struct RatatuiRenderWidget<'a> {
 
 impl<'a> RatatuiRenderWidget<'a> {
     pub fn new(image: &'a Image) -> Self {
-        let mut picker = Picker::new((1, 2));
-        picker.protocol_type = ProtocolType::Halfblocks;
+        let mut picker = Picker::from_fontsize((1, 2));
+        picker.set_protocol_type(ProtocolType::Halfblocks);
 
         Self { image, picker }
     }
@@ -45,6 +45,6 @@ impl<'a> Widget for RatatuiRenderWidget<'a> {
             .new_protocol(image, render_area, Resize::Fit(None))
             .unwrap();
 
-        ratatui_image::Image::new(img_as_halfblocks.as_ref()).render(render_area, buf);
+        ratatui_image::Image::new(&img_as_halfblocks).render(render_area, buf);
     }
 }


### PR DESCRIPTION
## 🤖 New release
* `bevy_ratatui_render`: 0.5.8 -> 0.5.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.9](https://github.com/cxreiff/bevy_ratatui_render/compare/v0.5.8...v0.5.9) - 2024-11-26

### Other

- ratatui 0.29, ratatui-image 3.0
- added linux_dependencies to check workflow
- update secret name in workflows
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).