### PR TITLE
chore: release v0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.9](https://github.com/cxreiff/bevy_ratatui_render/compare/v0.5.8...v0.5.9) - 2024-11-26
+
+### Added
+
+- ratatui 0.29, ratatui-image 3.0
+
+### Other
+
+- added linux_dependencies to check workflow
+- update secret name in workflows
+
 ## [0.5.8](https://github.com/cxreiff/bevy_ratatui_render/compare/v0.5.7...v0.5.8) - 2024-10-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ratatui_render"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bevy",
  "bevy_ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui_render"
 description = "A bevy plugin for rendering your bevy app to the terminal using ratatui."
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 authors = ["cxreiff <cooper@cxreiff.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `bevy_ratatui_render`: 0.5.8 -> 0.5.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.9](https://github.com/cxreiff/bevy_ratatui_render/compare/v0.5.8...v0.5.9) - 2024-11-26

### Added

- ratatui 0.29, ratatui-image 3.0

### Other

- added linux_dependencies to check workflow
- update secret name in workflows
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).