### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/cxreiff/bevy_ratatui_render/compare/v0.6.0...v0.7.0) - 2024-12-05
+
+### Added
+
+- [**breaking**] bevy 0.15 migration
+
+### Other
+
+- Bump ruzstd from 0.7.0 to 0.7.3 in the cargo group across 1 directory
+- updated README for version bump
+
 ## [0.5.8](https://github.com/cxreiff/bevy_ratatui_render/compare/v0.5.7...v0.5.8) - 2024-10-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ratatui_render"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bevy",
  "bevy_ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui_render"
 description = "A bevy plugin for rendering your bevy app to the terminal using ratatui."
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["cxreiff <cooper@cxreiff.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `bevy_ratatui_render`: 0.6.0 -> 0.7.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.0](https://github.com/cxreiff/bevy_ratatui_render/compare/v0.6.0...v0.7.0) - 2024-12-05

### Added

- [**breaking**] bevy 0.15 migration

### Other

- Bump ruzstd from 0.7.0 to 0.7.3 in the cargo group across 1 directory
- updated README for version bump
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).