### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.7.0...v0.8.0) - 2024-12-23
+
+### Other
+
+- added edge_detection example
+
 ## [0.7.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.6.0...v0.7.0) - 2024-12-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ratatui_camera"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "bevy_mod_debugdump",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui_camera"
 description = "A bevy plugin for rendering your bevy app to the terminal using ratatui."
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["cxreiff <cooper@cxreiff.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `bevy_ratatui_camera`: 0.7.0 -> 0.8.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.7.0...v0.8.0) - 2024-12-23

### Other

- added edge_detection example
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).