### PR TITLE
chore: release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.8.1...v0.8.2) - 2024-12-31
+
+### Fixed
+
+- better diagonals font compatibility
+
 ## [0.8.1](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.8.0...v0.8.1) - 2024-12-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ratatui_camera"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "bevy",
  "bevy_mod_debugdump",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui_camera"
 description = "A bevy plugin for rendering your bevy app to the terminal using ratatui."
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = ["cxreiff <cooper@cxreiff.com>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ when the text rendering causes edges to blend together.
 
 Set `edge_characters` to `EdgeCharacters::Single(..)` for a single dedicated edge character, or set it to
 `EdgeCharacters::Directional { .. }` to set different characters based on the "direction" of the edge, for
-example using '―', '|', '⟋', and '⟍' characters to draw edge "lines". Detecting the correct edge direction
+example using '―', '|', '/', and '\\' characters to draw edge "lines". Detecting the correct edge direction
 is a bit fuzzy, so you may need to experiment with color/depth/normal thresholds for good results.
 
 ```rust
@@ -127,8 +127,8 @@ RatatuiCameraEdgeDetection {
     edge_characters: Self::Directional {
         vertical: '|',
         horizontal: '―',
-        forward_diagonal: '⟋',
-        backward_diagonal: '⟍',
+        forward_diagonal: '/',
+        backward_diagonal: '\\',
     },
     edge_color: Some(ratatui::style::Color::Magenta),
     ..default()
@@ -149,6 +149,8 @@ that the following terminals display correctly:
 - Kitty
 - iTerm
 - WezTerm
+- Rio
+- Ghostty
 
 ...but any terminal with 24-bit color support should work fine, if its performance is adequate.
 

--- a/examples/luminance.rs
+++ b/examples/luminance.rs
@@ -11,8 +11,10 @@ use bevy::winit::WinitPlugin;
 use bevy_ratatui::kitty::KittyEnabled;
 use bevy_ratatui::terminal::RatatuiContext;
 use bevy_ratatui::RatatuiPlugins;
+use bevy_ratatui_camera::EdgeCharacters;
 use bevy_ratatui_camera::LuminanceConfig;
 use bevy_ratatui_camera::RatatuiCamera;
+use bevy_ratatui_camera::RatatuiCameraEdgeDetection;
 use bevy_ratatui_camera::RatatuiCameraPlugin;
 use bevy_ratatui_camera::RatatuiCameraStrategy;
 use bevy_ratatui_camera::RatatuiCameraWidget;
@@ -60,6 +62,13 @@ fn setup_scene_system(
             luminance_scale: 11.0,
             ..default()
         }),
+        RatatuiCameraEdgeDetection {
+            edge_characters: EdgeCharacters::Single('+'),
+            edge_color: Some(ratatui::style::Color::Magenta),
+            color_enabled: false,
+            normal_enabled: false,
+            ..default()
+        },
         Camera3d::default(),
         Transform::from_xyz(2.5, 2.5, 2.5).looking_at(Vec3::ZERO, Vec3::Z),
     ));

--- a/src/camera_edge_detection.rs
+++ b/src/camera_edge_detection.rs
@@ -77,8 +77,8 @@ impl Default for EdgeCharacters {
         Self::Directional {
             vertical: '|',
             horizontal: '―',
-            forward_diagonal: '⟋',
-            backward_diagonal: '⟍',
+            forward_diagonal: '/',
+            backward_diagonal: '\\',
         }
     }
 }


### PR DESCRIPTION
## 🤖 New release
* `bevy_ratatui_camera`: 0.8.1 -> 0.8.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.2](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.8.1...v0.8.2) - 2024-12-31

### Fixed

- better diagonals font compatibility
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).