### PR TITLE
transparency feature with masking color

### DIFF
--- a/examples/masking.rs
+++ b/examples/masking.rs
@@ -1,0 +1,98 @@
+use std::time::Duration;
+
+use bevy::app::ScheduleRunnerPlugin;
+use bevy::diagnostic::DiagnosticsStore;
+use bevy::diagnostic::FrameTimeDiagnosticsPlugin;
+use bevy::log::LogPlugin;
+use bevy::prelude::*;
+use bevy::utils::error;
+use bevy::winit::WinitPlugin;
+use bevy_ratatui::RatatuiPlugins;
+use bevy_ratatui::kitty::KittyEnabled;
+use bevy_ratatui::terminal::RatatuiContext;
+use bevy_ratatui_camera::EdgeCharacters;
+use bevy_ratatui_camera::LuminanceConfig;
+use bevy_ratatui_camera::RatatuiCamera;
+use bevy_ratatui_camera::RatatuiCameraEdgeDetection;
+use bevy_ratatui_camera::RatatuiCameraPlugin;
+use bevy_ratatui_camera::RatatuiCameraStrategy;
+use bevy_ratatui_camera::RatatuiCameraWidget;
+
+mod shared;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins
+                .set(ImagePlugin::default_nearest())
+                .disable::<WinitPlugin>()
+                .disable::<LogPlugin>(),
+            ScheduleRunnerPlugin::run_loop(Duration::from_secs_f64(1. / 60.)),
+            FrameTimeDiagnosticsPlugin,
+            RatatuiPlugins::default(),
+            RatatuiCameraPlugin,
+        ))
+        .init_resource::<shared::Flags>()
+        .init_resource::<shared::InputState>()
+        .insert_resource(ClearColor(Color::BLACK))
+        .add_systems(Startup, setup_scene_system)
+        .add_systems(Update, draw_scene_system.map(error))
+        .add_systems(PreUpdate, shared::handle_input_system)
+        .add_systems(Update, shared::rotate_spinners_system)
+        .run();
+}
+
+#[derive(Component)]
+pub struct Foreground;
+
+#[derive(Component)]
+pub struct Background;
+
+fn setup_scene_system(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    shared::spawn_3d_scene(&mut commands, &mut meshes, &mut materials);
+
+    commands.spawn((
+        Foreground,
+        RatatuiCamera::default(),
+        RatatuiCameraStrategy::Luminance(LuminanceConfig {
+            mask_color: Some(ratatui::style::Color::Rgb(0, 0, 0)),
+            ..default()
+        }),
+        RatatuiCameraEdgeDetection {
+            edge_color: Some(ratatui::style::Color::Rgb(255, 0, 255)),
+            edge_characters: EdgeCharacters::Single('#'),
+            ..Default::default()
+        },
+        Camera3d::default(),
+        Transform::from_xyz(6., 0., 2.).looking_at(Vec3::ZERO, Vec3::Z),
+    ));
+    commands.spawn((
+        Background,
+        RatatuiCamera::default(),
+        RatatuiCameraStrategy::luminance_misc(),
+        Camera3d::default(),
+        Transform::from_xyz(3., 0., 1.).looking_at(Vec3::ZERO, Vec3::Z),
+    ));
+}
+
+pub fn draw_scene_system(
+    mut ratatui: ResMut<RatatuiContext>,
+    foreground_widget: Query<&RatatuiCameraWidget, With<Foreground>>,
+    background_widget: Query<&RatatuiCameraWidget, With<Background>>,
+    flags: Res<shared::Flags>,
+    diagnostics: Res<DiagnosticsStore>,
+    kitty_enabled: Option<Res<KittyEnabled>>,
+) -> std::io::Result<()> {
+    ratatui.draw(|frame| {
+        let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
+
+        frame.render_widget(background_widget.single(), area);
+        frame.render_widget(foreground_widget.single(), area);
+    })?;
+
+    Ok(())
+}

--- a/examples/shared/mod.rs
+++ b/examples/shared/mod.rs
@@ -25,6 +25,7 @@ pub struct Flags {
     pub debug: bool,
 }
 
+#[allow(dead_code)]
 pub fn setup_tui_logger(filter: LevelFilter) {
     init_logger(filter).unwrap();
     set_default_level(filter);

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -132,7 +132,7 @@ pub enum RatatuiCameraStrategy {
     Luminance(LuminanceConfig),
 
     /// Does not print characters by itself, but edge detection will still print. Use with edge
-    /// detection for a "wireframe" type look.
+    /// detection for a "wireframe".
     None,
 }
 
@@ -167,7 +167,7 @@ impl RatatuiCameraStrategy {
 /// # Example:
 ///
 /// The following would configure the widget to multiply each pixel's luminance value by 5.0, use
-/// ' ' and '.' for dimmer areas, and use '+' and '#' for brighter areas:
+/// ' ' and '.' for dimmer areas, use '+' and '#' for brighter areas, and skip using a mask color:
 ///
 /// ```no_run
 /// # use bevy::prelude::*;
@@ -179,6 +179,7 @@ impl RatatuiCameraStrategy {
 ///     RatatuiCameraStrategy::Luminance(LuminanceConfig {
 ///         luminance_characters: vec![' ', '.', '+', '#'],
 ///         luminance_scale: 5.0,
+///         mask_color: None,
 ///     }),
 /// # ));
 /// # };
@@ -196,6 +197,18 @@ pub struct LuminanceConfig {
     /// a character. Because most scenes do not occupy the full range of luminance between 0.0 and
     /// 1.0, each luminance value is multiplied by a scaling value first.
     pub luminance_scale: f32,
+
+    /// An optional mask color for creating transparency effects. Skips writing any character to
+    /// the terminal buffer that matches the provided color.
+    ///
+    /// For example, set it to `Some(Color::Rgb(0, 0, 0)` in a scene with a foreground object in
+    /// front of a black background, to render that object without the background space overwriting
+    /// the cells currently in the buffer.
+    ///
+    /// Useful for compositing together multiple rendered layers. There should generally always be
+    /// at least one non-masked layer furthest back, as otherwise stray cells in the terminal
+    /// buffer might not get replaced between frames.
+    pub mask_color: Option<ratatui::style::Color>,
 }
 
 impl LuminanceConfig {
@@ -219,6 +232,7 @@ impl Default for LuminanceConfig {
         Self {
             luminance_characters: LuminanceConfig::LUMINANCE_CHARACTERS_BRAILLE.into(),
             luminance_scale: LuminanceConfig::LUMINANCE_SCALE_DEFAULT,
+            mask_color: None,
         }
     }
 }

--- a/src/widget_luminance.rs
+++ b/src/widget_luminance.rs
@@ -116,6 +116,13 @@ impl WidgetRef for RatatuiCameraWidgetLuminance<'_> {
                 }
             };
 
+            if strategy_config
+                .mask_color
+                .is_some_and(|mask_color| mask_color == color)
+            {
+                continue;
+            }
+
             if let Some(cell) = buf.cell_mut((render_area.x + x, render_area.y + y)) {
                 cell.set_fg(color).set_char(character);
             }


### PR DESCRIPTION
When using the Luminance character conversion strategy, you can supply a `mask_color` that acts as a "green screen" for skipping cells when drawing to the terminal buffer cells.

Useful for transparency effects, useful when compositing the output of multiple cameras together.