### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.8.2...v0.9.0) - 2025-03-01
+
+### Other
+
+- transparency feature with masking color
+- added subcamera for compositing cameras
+- rust 2024 edition migration
+
 ## [0.8.2](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.8.1...v0.8.2) - 2024-12-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ratatui_camera"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "bevy",
  "bevy_mod_debugdump",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui_camera"
 description = "A bevy plugin for rendering your bevy app to the terminal using ratatui."
-version = "0.8.2"
+version = "0.9.0"
 edition = "2024"
 authors = ["cxreiff <cooper@cxreiff.com>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -174,6 +174,6 @@ performance is adequate.
 
 | bevy  | bevy_ratatui_camera |
 |-------|---------------------|
-| 0.15  | 0.8                 |
+| 0.15  | 0.9                 |
 | 0.14  | 0.6                 |
 


### PR DESCRIPTION



## 🤖 New release

* `bevy_ratatui_camera`: 0.8.2 -> 0.9.0 (⚠ API breaking changes)

### ⚠ `bevy_ratatui_camera` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field LuminanceConfig.mask_color in /tmp/.tmpyl8i3A/bevy_ratatui_camera/src/camera.rs:211
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.8.2...v0.9.0) - 2025-03-01

### Other

- transparency feature with masking color
- added subcamera for compositing cameras
- rust 2024 edition migration
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).