### PR TITLE
reworked autoresize to work with render area

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ fn draw_scene_system(
     camera_widget: Query<&RatatuiCameraWidget>,
 ) -> std::io::Result<()> {
     ratatui.draw(|frame| {
-        frame.render_widget(camera_widget.single(), frame.area());
+        camera_widget.single().render(frame.area(), frame.buffer_mut());
     })?;
 
     Ok(())
@@ -97,21 +97,20 @@ commands.spawn((
 ## autoresize
 
 By default, the size of the texture the camera renders to will stay constant,
-and when rendered to the ratatui buffer it will retain its aspect ratio. If you
-set the `autoresize` attribute to true, the render texture will be resized to
-fit the terminal window, including its aspect ratio.
-
-You can also supply an optional `autoresize_function` that converts the
-terminal dimensions to the dimensions that will be used for resizing. This is
-useful for situations when you want to maintain a specific aspect ratio or
-resize to some fraction of the terminal window.
+and when rendered to the ratatui buffer with `RatatuiCameraWidget::render(...)`
+it will retain its aspect ratio. If you use the
+`RatatuiCameraWidget::render_autoresize` variant instead, whenever the render
+texture doesn't match the size of the render area, rendering will be skipped
+that frame and a resize of the render texture will be triggered instead.
 
 ```rust
-RatatuiCamera {
-    autoresize: true,
-    autoresize_fn: |(w, h)| (w * 4, h * 3),
-    ..default()
-}
+ratatui.draw(|frame| {
+    camera_widget.single().render_autoresize(
+        frame.area(),
+        frame.buffer_mut(),
+        &mut commands,
+    );
+})?;
 ```
 
 ## edge detection

--- a/examples/2d_camera.rs
+++ b/examples/2d_camera.rs
@@ -50,15 +50,16 @@ fn setup_scene_system(
     shared::spawn_2d_scene(&mut commands, &mut meshes, &mut materials);
 
     commands.spawn((
-        RatatuiCamera::autoresize(),
+        RatatuiCamera::default(),
         RatatuiCameraStrategy::Luminance(LuminanceConfig::default()),
         Camera2d,
     ));
 }
 
 pub fn draw_scene_system(
+    mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
-    ratatui_camera_widget: Query<&RatatuiCameraWidget>,
+    camera_widget: Query<&RatatuiCameraWidget>,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,
@@ -66,9 +67,9 @@ pub fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        if let Ok(camera_widget) = ratatui_camera_widget.get_single() {
-            frame.render_widget(camera_widget, area);
-        }
+        camera_widget
+            .single()
+            .render_autoresize(area, frame.buffer_mut(), &mut commands);
     })?;
 
     Ok(())

--- a/examples/3d_camera.rs
+++ b/examples/3d_camera.rs
@@ -14,6 +14,7 @@ use bevy_ratatui_camera::RatatuiCamera;
 use bevy_ratatui_camera::RatatuiCameraPlugin;
 use bevy_ratatui_camera::RatatuiCameraWidget;
 use log::LevelFilter;
+use ratatui::widgets::Widget;
 
 mod shared;
 
@@ -57,7 +58,7 @@ fn setup_scene_system(
 
 pub fn draw_scene_system(
     mut ratatui: ResMut<RatatuiContext>,
-    ratatui_camera_widget: Query<&RatatuiCameraWidget>,
+    camera_widget: Query<&RatatuiCameraWidget>,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,
@@ -65,9 +66,7 @@ pub fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        if let Ok(camera_widget) = ratatui_camera_widget.get_single() {
-            frame.render_widget(camera_widget, area);
-        }
+        camera_widget.single().render(area, frame.buffer_mut());
     })?;
 
     Ok(())

--- a/examples/edge_detection.rs
+++ b/examples/edge_detection.rs
@@ -52,7 +52,7 @@ fn setup_scene_system(
     shared::spawn_3d_scene(&mut commands, &mut meshes, &mut materials);
 
     commands.spawn((
-        RatatuiCamera::autoresize(),
+        RatatuiCamera::default(),
         RatatuiCameraStrategy::None,
         RatatuiCameraEdgeDetection::default(),
         Camera3d::default(),
@@ -61,8 +61,9 @@ fn setup_scene_system(
 }
 
 pub fn draw_scene_system(
+    mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
-    ratatui_camera_widget: Query<&RatatuiCameraWidget>,
+    camera_widget: Query<&RatatuiCameraWidget>,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,
@@ -70,9 +71,9 @@ pub fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        if let Ok(camera_widget) = ratatui_camera_widget.get_single() {
-            frame.render_widget(camera_widget, area);
-        }
+        camera_widget
+            .single()
+            .render_autoresize(area, frame.buffer_mut(), &mut commands);
     })?;
 
     Ok(())

--- a/examples/luminance.rs
+++ b/examples/luminance.rs
@@ -11,7 +11,6 @@ use bevy::winit::WinitPlugin;
 use bevy_ratatui::RatatuiPlugins;
 use bevy_ratatui::kitty::KittyEnabled;
 use bevy_ratatui::terminal::RatatuiContext;
-use bevy_ratatui_camera::LuminanceConfig;
 use bevy_ratatui_camera::RatatuiCamera;
 use bevy_ratatui_camera::RatatuiCameraPlugin;
 use bevy_ratatui_camera::RatatuiCameraStrategy;
@@ -52,19 +51,17 @@ fn setup_scene_system(
     shared::spawn_3d_scene(&mut commands, &mut meshes, &mut materials);
 
     commands.spawn((
-        RatatuiCamera::autoresize(),
-        RatatuiCameraStrategy::Luminance(LuminanceConfig {
-            luminance_scale: 11.0,
-            ..default()
-        }),
+        RatatuiCamera::default(),
+        RatatuiCameraStrategy::luminance_misc(),
         Camera3d::default(),
         Transform::from_xyz(2.5, 2.5, 2.5).looking_at(Vec3::ZERO, Vec3::Z),
     ));
 }
 
 pub fn draw_scene_system(
+    mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
-    ratatui_camera_widget: Query<&RatatuiCameraWidget>,
+    camera_widget: Query<&RatatuiCameraWidget>,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,
@@ -72,9 +69,9 @@ pub fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        if let Ok(camera_widget) = ratatui_camera_widget.get_single() {
-            frame.render_widget(camera_widget, area);
-        }
+        camera_widget
+            .single()
+            .render_autoresize(area, frame.buffer_mut(), &mut commands);
     })?;
 
     Ok(())

--- a/examples/masking.rs
+++ b/examples/masking.rs
@@ -80,6 +80,7 @@ fn setup_scene_system(
 }
 
 pub fn draw_scene_system(
+    mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
     foreground_widget: Query<&RatatuiCameraWidget, With<Foreground>>,
     background_widget: Query<&RatatuiCameraWidget, With<Background>>,
@@ -90,8 +91,12 @@ pub fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        frame.render_widget(background_widget.single(), area);
-        frame.render_widget(foreground_widget.single(), area);
+        background_widget
+            .single()
+            .render_autoresize(area, frame.buffer_mut(), &mut commands);
+        foreground_widget
+            .single()
+            .render_autoresize(area, frame.buffer_mut(), &mut commands);
     })?;
 
     Ok(())

--- a/examples/orthographic.rs
+++ b/examples/orthographic.rs
@@ -52,7 +52,7 @@ fn setup_scene_system(
     shared::spawn_3d_scene(&mut commands, &mut meshes, &mut materials);
 
     commands.spawn((
-        RatatuiCamera::autoresize(),
+        RatatuiCamera::default(),
         RatatuiCameraStrategy::Luminance(LuminanceConfig::default()),
         Camera3d::default(),
         Transform::from_xyz(2.5, 2.5, 2.5).looking_at(Vec3::ZERO, Vec3::Z),
@@ -64,8 +64,9 @@ fn setup_scene_system(
 }
 
 pub fn draw_scene_system(
+    mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
-    ratatui_camera_widget: Query<&RatatuiCameraWidget>,
+    camera_widget: Query<&RatatuiCameraWidget>,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,
@@ -73,9 +74,9 @@ pub fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        if let Ok(camera_widget) = ratatui_camera_widget.get_single() {
-            frame.render_widget(camera_widget, area);
-        }
+        camera_widget
+            .single()
+            .render_autoresize(area, frame.buffer_mut(), &mut commands);
     })?;
 
     Ok(())

--- a/examples/shared/mod.rs
+++ b/examples/shared/mod.rs
@@ -81,7 +81,7 @@ pub fn debug_frame(
 ) -> Rect {
     let mut block = Block::bordered()
         .bg(ratatui::style::Color::Rgb(0, 0, 0))
-        .border_style(Style::default().bg(ratatui::style::Color::Rgb(0, 0, 0)))
+        .border_style(Style::default().bg(ratatui::style::Color::Black))
         .title_bottom("[q for quit]")
         .title_bottom("[d for debug]")
         .title_bottom("[p for panic]")

--- a/examples/subcamera.rs
+++ b/examples/subcamera.rs
@@ -15,9 +15,6 @@ use bevy_ratatui_camera::RatatuiCameraPlugin;
 use bevy_ratatui_camera::RatatuiCameraWidget;
 use bevy_ratatui_camera::RatatuiSubcamera;
 use log::LevelFilter;
-use ratatui::layout::Constraint;
-use ratatui::layout::Direction;
-use ratatui::layout::Layout;
 
 mod shared;
 
@@ -54,7 +51,7 @@ fn setup_scene_system(
 
     let main_camera_id = commands
         .spawn((
-            RatatuiCamera::autoresize(),
+            RatatuiCamera::default(),
             Camera3d::default(),
             Transform::from_xyz(2., 1., 1.).looking_at(Vec3::Y, Vec3::Z),
         ))
@@ -68,8 +65,9 @@ fn setup_scene_system(
 }
 
 pub fn draw_scene_system(
+    mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
-    ratatui_camera_widgets: Query<&RatatuiCameraWidget>,
+    camera_widget: Query<&RatatuiCameraWidget>,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,
@@ -77,20 +75,9 @@ pub fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        let widgets = ratatui_camera_widgets
-            .iter()
-            .enumerate()
-            .collect::<Vec<_>>();
-
-        let layout = Layout::new(
-            Direction::Horizontal,
-            vec![Constraint::Fill(1); widgets.len()],
-        )
-        .split(area);
-
-        for (i, widget) in widgets {
-            frame.render_widget(widget, layout[i]);
-        }
+        camera_widget
+            .single()
+            .render_autoresize(area, frame.buffer_mut(), &mut commands);
     })?;
 
     Ok(())

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -22,23 +22,12 @@ use bevy::prelude::*;
 pub struct RatatuiCamera {
     /// Dimensions (width, height) of the image the camera will render to.
     pub dimensions: (u32, u32),
-
-    /// If true, the rendered image dimensions will be resized to match the size and aspect ratio
-    /// of the terminal window (at startup and whenever a terminal resize event is received).
-    pub autoresize: bool,
-
-    /// When autoresize is true, this function will be used to transform the new terminal
-    /// dimensions into the rendered image dimensions. For example, use `|(w, h)| (w*4, h*3)` to
-    /// maintain a 4:3 aspect ratio.
-    pub autoresize_fn: fn((u32, u32)) -> (u32, u32),
 }
 
 impl Default for RatatuiCamera {
     fn default() -> Self {
         Self {
             dimensions: (256, 256),
-            autoresize: false,
-            autoresize_fn: |(w, h)| (w * 2, h * 2),
         }
     }
 }
@@ -46,38 +35,7 @@ impl Default for RatatuiCamera {
 impl RatatuiCamera {
     /// Creates a new RatatuiCamera that renders to an image of the provided dimensions.
     pub fn new(dimensions: (u32, u32)) -> Self {
-        Self {
-            dimensions,
-            ..default()
-        }
-    }
-
-    /// Creates a new RatatuiCamera that will automatically resize to the terminal dimensions.
-    ///
-    /// Providing dimensions is not necessary as they will be replaced on the first frame.
-    pub fn autoresize() -> Self {
-        Self {
-            autoresize: true,
-            ..default()
-        }
-    }
-
-    /// Mutates RatatuiCamera to use new provided dimensions.
-    pub fn with_dimensions(mut self, dimensions: (u32, u32)) -> Self {
-        self.dimensions = dimensions;
-        self
-    }
-
-    /// Mutates RatatuiCamera to use new provided autoresize setting.
-    pub fn with_autoresize(mut self, autoresize: bool) -> Self {
-        self.autoresize = autoresize;
-        self
-    }
-
-    /// Mutates RatatuiCamera to use new provided autoresize function.
-    pub fn with_autoresize_fn(mut self, autoresize_fn: fn((u32, u32)) -> (u32, u32)) -> Self {
-        self.autoresize_fn = autoresize_fn;
-        self
+        Self { dimensions }
     }
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -21,6 +21,7 @@ use crate::{
 /// # use bevy_ratatui::RatatuiPlugins;
 /// # use bevy_ratatui::terminal::RatatuiContext;
 /// # use bevy_ratatui_camera::{RatatuiCamera, RatatuiCameraPlugin, RatatuiCameraWidget};
+/// # use ratatui::prelude::Widget;
 /// #
 /// fn main() {
 ///     App::new()
@@ -58,7 +59,7 @@ use crate::{
 ///     camera_widget: Query<&RatatuiCameraWidget>,
 /// ) -> std::io::Result<()> {
 ///     ratatui.draw(|frame| {
-///         frame.render_widget(camera_widget.single(), frame.area());
+///         camera_widget.single().render(frame.area(), frame.buffer_mut());
 ///     })?;
 ///
 ///     Ok(())


### PR DESCRIPTION
The previous autoresize functionality wasn't very flexible, as it was tied to window size as opposed to render_area size. Any layout other than complete fullscreen meant that the dimensions provided by crossterm resize events wouldn't be the same as the area the RatatuiCameraWidget would be rendered in. `autoresize_fn` was provided as a workaround to adjust the dimensions proportionally after the fact, but it is unnecessary manual work for the user when 99% of the time people just want the render texture to fill the ratatui area `Rect` that it's being rendered in.

That autoresize functionality has been removed and replaced by a new way to resize each frame: `RatatuiCameraWidget::render_autoresize(...)`.

Just call `render_autoresize` in your draw function instead of `render` and any frame where there is a size mismatch, rendering will be skipped and a resize will be triggered instead.