### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.9.0...v0.10.0) - 2025-03-02
+
+### Other
+
+- reworked autoresize to work with render area
+
 ## [0.9.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.8.2...v0.9.0) - 2025-03-01
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ratatui_camera"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bevy",
  "bevy_mod_debugdump",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui_camera"
 description = "A bevy plugin for rendering your bevy app to the terminal using ratatui."
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 authors = ["cxreiff <cooper@cxreiff.com>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -173,6 +173,6 @@ performance is adequate.
 
 | bevy  | bevy_ratatui_camera |
 |-------|---------------------|
-| 0.15  | 0.9                 |
+| 0.15  | 0.10                |
 | 0.14  | 0.6                 |
 


### PR DESCRIPTION



## 🤖 New release

* `bevy_ratatui_camera`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)

### ⚠ `bevy_ratatui_camera` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RatatuiCameraWidget.entity in /tmp/.tmpGBSKfH/bevy_ratatui_camera/src/widget.rs:20
  field RatatuiCameraWidget.ratatui_camera in /tmp/.tmpGBSKfH/bevy_ratatui_camera/src/widget.rs:23

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/inherent_method_missing.ron

Failed in:
  RatatuiCamera::autoresize, previously in file /tmp/.tmpl7zYOg/bevy_ratatui_camera/src/camera.rs:58
  RatatuiCamera::with_dimensions, previously in file /tmp/.tmpl7zYOg/bevy_ratatui_camera/src/camera.rs:66
  RatatuiCamera::with_autoresize, previously in file /tmp/.tmpl7zYOg/bevy_ratatui_camera/src/camera.rs:72
  RatatuiCamera::with_autoresize_fn, previously in file /tmp/.tmpl7zYOg/bevy_ratatui_camera/src/camera.rs:78

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field autoresize of struct RatatuiCamera, previously in file /tmp/.tmpl7zYOg/bevy_ratatui_camera/src/camera.rs:28
  field autoresize_fn of struct RatatuiCamera, previously in file /tmp/.tmpl7zYOg/bevy_ratatui_camera/src/camera.rs:33
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.9.0...v0.10.0) - 2025-03-02

### Other

- reworked autoresize to work with render area
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).