### PR TITLE
Added a SystemSet for main update loop systems, new dynamic_config example

### DIFF
--- a/examples/2d_camera.rs
+++ b/examples/2d_camera.rs
@@ -56,7 +56,7 @@ fn setup_scene_system(
     ));
 }
 
-pub fn draw_scene_system(
+fn draw_scene_system(
     mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
     camera_widget: Query<&RatatuiCameraWidget>,

--- a/examples/3d_camera.rs
+++ b/examples/3d_camera.rs
@@ -56,7 +56,7 @@ fn setup_scene_system(
     ));
 }
 
-pub fn draw_scene_system(
+fn draw_scene_system(
     mut ratatui: ResMut<RatatuiContext>,
     camera_widget: Query<&RatatuiCameraWidget>,
     flags: Res<shared::Flags>,

--- a/examples/dynamic_config.rs
+++ b/examples/dynamic_config.rs
@@ -1,0 +1,187 @@
+use std::time::Duration;
+
+use bevy::app::ScheduleRunnerPlugin;
+use bevy::color::Color;
+use bevy::diagnostic::DiagnosticsStore;
+use bevy::diagnostic::FrameTimeDiagnosticsPlugin;
+use bevy::ecs::system::RegisteredSystemError;
+use bevy::ecs::system::SystemState;
+use bevy::log::LogPlugin;
+use bevy::prelude::*;
+use bevy::utils::error;
+use bevy::winit::WinitPlugin;
+use bevy_ratatui::RatatuiPlugins;
+use bevy_ratatui::event::KeyEvent;
+use bevy_ratatui::kitty::KittyEnabled;
+use bevy_ratatui::terminal::RatatuiContext;
+use bevy_ratatui_camera::LuminanceConfig;
+use bevy_ratatui_camera::RatatuiCamera;
+use bevy_ratatui_camera::RatatuiCameraEdgeDetection;
+use bevy_ratatui_camera::RatatuiCameraPlugin;
+use bevy_ratatui_camera::RatatuiCameraStrategy;
+use bevy_ratatui_camera::RatatuiCameraWidget;
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEventKind;
+use log::LevelFilter;
+
+mod shared;
+
+fn main() {
+    shared::setup_tui_logger(LevelFilter::Info);
+
+    App::new()
+        .add_plugins((
+            DefaultPlugins
+                .build()
+                .disable::<WinitPlugin>()
+                .disable::<LogPlugin>(),
+            ScheduleRunnerPlugin::run_loop(Duration::from_secs_f64(1. / 60.)),
+            FrameTimeDiagnosticsPlugin,
+            RatatuiPlugins::default(),
+            RatatuiCameraPlugin,
+        ))
+        .init_resource::<shared::Flags>()
+        .init_resource::<shared::InputState>()
+        .insert_resource(ClearColor(Color::BLACK))
+        .add_systems(Startup, setup_scene_system)
+        .add_systems(Update, draw_scene_system.map(error))
+        .add_systems(PreUpdate, shared::handle_input_system)
+        .add_systems(Update, shared::rotate_spinners_system)
+        .add_systems(Update, handle_input_system.map(error))
+        .run();
+}
+
+fn setup_scene_system(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    shared::spawn_3d_scene(&mut commands, &mut meshes, &mut materials);
+
+    commands.spawn((
+        RatatuiCamera::default(),
+        Camera3d::default(),
+        Transform::from_xyz(2.5, 2.5, 2.5).looking_at(Vec3::ZERO, Vec3::Z),
+    ));
+}
+
+fn draw_scene_system(
+    mut commands: Commands,
+    mut ratatui: ResMut<RatatuiContext>,
+    camera_widget: Query<&RatatuiCameraWidget>,
+    flags: Res<shared::Flags>,
+    diagnostics: Res<DiagnosticsStore>,
+    kitty_enabled: Option<Res<KittyEnabled>>,
+) -> std::io::Result<()> {
+    ratatui.draw(|frame| {
+        let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
+
+        camera_widget
+            .single()
+            .render_autoresize(area, frame.buffer_mut(), &mut commands);
+    })?;
+
+    Ok(())
+}
+
+#[derive(Resource, Default, Clone)]
+pub enum CameraState {
+    #[default]
+    Start,
+    SwitchedStrategy,
+    AddedEdges,
+    ChangedCharacters,
+    ChangedEdgeColor,
+}
+
+pub fn handle_input_system(
+    world: &mut World,
+    system_state: &mut SystemState<EventReader<KeyEvent>>,
+    mut camera_state: Local<CameraState>,
+) -> Result<(), RegisteredSystemError> {
+    let mut event_reader = system_state.get_mut(world);
+    let events: Vec<_> = event_reader.read().cloned().collect();
+
+    for key_event in events.iter() {
+        if let KeyEventKind::Press = key_event.kind {
+            if let KeyCode::Char(' ') = key_event.code {
+                match *camera_state {
+                    CameraState::Start => {
+                        world.run_system_cached(toggle_ratatui_camera_strategy)?;
+                        *camera_state = CameraState::SwitchedStrategy;
+                    }
+                    CameraState::SwitchedStrategy => {
+                        world.run_system_cached(toggle_edge_detection_system)?;
+                        *camera_state = CameraState::AddedEdges;
+                    }
+                    CameraState::AddedEdges => {
+                        world.run_system_cached(modify_ratatui_camera_strategy)?;
+                        *camera_state = CameraState::ChangedCharacters;
+                    }
+                    CameraState::ChangedCharacters => {
+                        world.run_system_cached(modify_edge_detection_system)?;
+                        *camera_state = CameraState::ChangedEdgeColor;
+                    }
+                    CameraState::ChangedEdgeColor => {
+                        world.run_system_cached(toggle_edge_detection_system)?;
+                        world.run_system_cached(toggle_ratatui_camera_strategy)?;
+                        *camera_state = CameraState::Start;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn toggle_edge_detection_system(
+    mut commands: Commands,
+    ratatui_camera: Query<(Entity, Option<&mut RatatuiCameraEdgeDetection>), With<RatatuiCamera>>,
+) {
+    let (entity, edge_detection) = ratatui_camera.single();
+    if edge_detection.is_some() {
+        commands
+            .entity(entity)
+            .remove::<RatatuiCameraEdgeDetection>();
+    } else {
+        commands
+            .entity(entity)
+            .insert(RatatuiCameraEdgeDetection::default());
+    }
+}
+
+fn modify_edge_detection_system(
+    mut ratatui_camera_edge_detection: Query<
+        Option<&mut RatatuiCameraEdgeDetection>,
+        With<RatatuiCamera>,
+    >,
+) {
+    if let Some(mut c) = ratatui_camera_edge_detection.single_mut() {
+        c.edge_color = Some(ratatui::style::Color::Magenta);
+    }
+}
+
+fn modify_ratatui_camera_strategy(mut ratatui_camera_strategy: Query<&mut RatatuiCameraStrategy>) {
+    let RatatuiCameraStrategy::Luminance(ref mut luminance_config) =
+        *ratatui_camera_strategy.single_mut()
+    else {
+        return;
+    };
+
+    luminance_config.luminance_characters = vec!['.', 'o', 'O', '0'];
+}
+
+fn toggle_ratatui_camera_strategy(
+    mut commands: Commands,
+    mut ratatui_camera: Query<(Entity, &RatatuiCameraStrategy)>,
+) {
+    let (entity, strategy) = ratatui_camera.single_mut();
+    commands.entity(entity).insert(match strategy {
+        RatatuiCameraStrategy::HalfBlocks => {
+            RatatuiCameraStrategy::Luminance(LuminanceConfig::default())
+        }
+        RatatuiCameraStrategy::Luminance(_) => RatatuiCameraStrategy::HalfBlocks,
+        RatatuiCameraStrategy::None => RatatuiCameraStrategy::None,
+    });
+}

--- a/examples/edge_detection.rs
+++ b/examples/edge_detection.rs
@@ -60,7 +60,7 @@ fn setup_scene_system(
     ));
 }
 
-pub fn draw_scene_system(
+fn draw_scene_system(
     mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
     camera_widget: Query<&RatatuiCameraWidget>,

--- a/examples/luminance.rs
+++ b/examples/luminance.rs
@@ -58,7 +58,7 @@ fn setup_scene_system(
     ));
 }
 
-pub fn draw_scene_system(
+fn draw_scene_system(
     mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
     camera_widget: Query<&RatatuiCameraWidget>,

--- a/examples/masking.rs
+++ b/examples/masking.rs
@@ -79,7 +79,7 @@ fn setup_scene_system(
     ));
 }
 
-pub fn draw_scene_system(
+fn draw_scene_system(
     mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
     foreground_widget: Query<&RatatuiCameraWidget, With<Foreground>>,

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -71,7 +71,7 @@ fn setup_scene_system(
     ));
 }
 
-pub fn draw_scene_system(
+fn draw_scene_system(
     mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
     camera_widgets: Query<&RatatuiCameraWidget>,

--- a/examples/orthographic.rs
+++ b/examples/orthographic.rs
@@ -63,7 +63,7 @@ fn setup_scene_system(
     ));
 }
 
-pub fn draw_scene_system(
+fn draw_scene_system(
     mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
     camera_widget: Query<&RatatuiCameraWidget>,

--- a/examples/shared/mod.rs
+++ b/examples/shared/mod.rs
@@ -140,12 +140,12 @@ pub enum InputState {
 
 #[allow(dead_code)]
 pub fn handle_input_system(
-    mut rat_events: EventReader<KeyEvent>,
+    mut ratatui_events: EventReader<KeyEvent>,
     mut exit: EventWriter<AppExit>,
     mut flags: ResMut<Flags>,
     mut input: ResMut<InputState>,
 ) {
-    for key_event in rat_events.read() {
+    for key_event in ratatui_events.read() {
         match key_event.kind {
             KeyEventKind::Press | KeyEventKind::Repeat => match key_event.code {
                 KeyCode::Char('q') => {

--- a/examples/subcamera.rs
+++ b/examples/subcamera.rs
@@ -64,7 +64,7 @@ fn setup_scene_system(
     ));
 }
 
-pub fn draw_scene_system(
+fn draw_scene_system(
     mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
     camera_widget: Query<&RatatuiCameraWidget>,

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,5 +1,7 @@
 use bevy::prelude::*;
 
+use crate::camera_strategy::RatatuiCameraStrategy;
+
 /// Spawn this component with your bevy camera in order to send each frame's rendered image to
 /// a RatatuiCameraWidget that will be inserted into the same camera entity.
 ///
@@ -74,123 +76,14 @@ pub struct RatatuiSubcamera(pub Entity);
 // #[relationship_target(relationship = RatatuiCameraTargeting)]
 // struct RatatuiCameraTargetedBy(Vec<Entity>);
 
-/// Specify the strategy used for converting the camera's rendered image to unicode characters for
-/// the terminal buffer. Insert a variant of this component alongside your `RatatuiCamera` to
-/// change the default behavior.
+/// System set for the systems that perform this crate's functionality. Because important pieces of
+/// this crate's functionality are provided by components that are not added by the user directly,
+/// but are inserted and updated by this crate's observers and event handlers (e.g.
+/// RatatuiCameraWidget), it is important to order your systems relative to this system set to make
+/// sure certain components are present and up-to-date.
 ///
-#[derive(Component, Clone, Debug, Default)]
-pub enum RatatuiCameraStrategy {
-    /// Print to the terminal using unicode halfblock characters. By using both the halfblock
-    /// (foreground) color and the background color, we can draw two pixels per buffer cell.
-    #[default]
-    HalfBlocks,
-
-    /// Given a range of unicode characters sorted in increasing order of opacity, use each pixel's
-    /// luminance to select a character from the range.
-    Luminance(LuminanceConfig),
-
-    /// Does not print characters by itself, but edge detection will still print. Use with edge
-    /// detection for a "wireframe".
-    None,
-}
-
-impl RatatuiCameraStrategy {
-    /// Luminance strategy with a range of braille unicode characters in increasing order of opacity.
-    pub fn luminance_braille() -> Self {
-        Self::Luminance(LuminanceConfig {
-            luminance_characters: LuminanceConfig::LUMINANCE_CHARACTERS_BRAILLE.into(),
-            ..default()
-        })
-    }
-
-    /// Luminance strategy with a range of miscellaneous characters in increasing order of opacity.
-    pub fn luminance_misc() -> Self {
-        Self::Luminance(LuminanceConfig {
-            luminance_characters: LuminanceConfig::LUMINANCE_CHARACTERS_MISC.into(),
-            ..default()
-        })
-    }
-
-    /// Luminance strategy with a range of block characters in increasing order of opacity.
-    pub fn luminance_shading() -> Self {
-        Self::Luminance(LuminanceConfig {
-            luminance_characters: LuminanceConfig::LUMINANCE_CHARACTERS_SHADING.into(),
-            ..default()
-        })
-    }
-}
-
-/// Configuration for the RatatuiCameraStrategy::Luminance terminal rendering strategy.
-///
-/// # Example:
-///
-/// The following would configure the widget to multiply each pixel's luminance value by 5.0, use
-/// ' ' and '.' for dimmer areas, use '+' and '#' for brighter areas, and skip using a mask color:
-///
-/// ```no_run
-/// # use bevy::prelude::*;
-/// # use bevy_ratatui_camera::{RatatuiCamera, RatatuiCameraStrategy, LuminanceConfig};
-/// #
-/// # fn setup_scene_system(mut commands: Commands) {
-/// # commands.spawn((
-/// #     RatatuiCamera::default(),
-///     RatatuiCameraStrategy::Luminance(LuminanceConfig {
-///         luminance_characters: vec![' ', '.', '+', '#'],
-///         luminance_scale: 5.0,
-///         mask_color: None,
-///     }),
-/// # ));
-/// # };
-/// ```
-///
-#[derive(Clone, Debug)]
-pub struct LuminanceConfig {
-    /// The list of characters, in increasing order of opacity, to use for printing. For example,
-    /// put an '@' symbol after a '+' symbol because it is more "opaque", taking up more space in
-    /// the cell it is printed in, and so when printed in bright text on a dark background, it
-    /// appears to be "brighter".
-    pub luminance_characters: Vec<char>,
-
-    /// The number that each luminance value is multiplied by before being used to select
-    /// a character. Because most scenes do not occupy the full range of luminance between 0.0 and
-    /// 1.0, each luminance value is multiplied by a scaling value first.
-    pub luminance_scale: f32,
-
-    /// An optional mask color for creating transparency effects. Skips writing any character to
-    /// the terminal buffer that matches the provided color.
-    ///
-    /// For example, set it to `Some(Color::Rgb(0, 0, 0)` in a scene with a foreground object in
-    /// front of a black background, to render that object without the background space overwriting
-    /// the cells currently in the buffer.
-    ///
-    /// Useful for compositing together multiple rendered layers. There should generally always be
-    /// at least one non-masked layer furthest back, as otherwise stray cells in the terminal
-    /// buffer might not get replaced between frames.
-    pub mask_color: Option<ratatui::style::Color>,
-}
-
-impl LuminanceConfig {
-    /// A range of braille unicode characters in increasing order of opacity.
-    pub const LUMINANCE_CHARACTERS_BRAILLE: &'static [char] =
-        &[' ', '⠂', '⠒', '⠖', '⠶', '⠷', '⠿', '⡿', '⣿'];
-
-    /// A range of miscellaneous characters in increasing order of opacity.
-    pub const LUMINANCE_CHARACTERS_MISC: &'static [char] =
-        &[' ', '.', ':', '+', '=', '!', '*', '?', '#', '%', '&', '@'];
-
-    /// A range of block characters in increasing order of opacity.
-    pub const LUMINANCE_CHARACTERS_SHADING: &'static [char] = &[' ', '░', '▒', '▓', '█'];
-
-    /// The default scaling value to multiply pixel luminance by.
-    const LUMINANCE_SCALE_DEFAULT: f32 = 10.;
-}
-
-impl Default for LuminanceConfig {
-    fn default() -> Self {
-        Self {
-            luminance_characters: LuminanceConfig::LUMINANCE_CHARACTERS_BRAILLE.into(),
-            luminance_scale: LuminanceConfig::LUMINANCE_SCALE_DEFAULT,
-            mask_color: None,
-        }
-    }
-}
+/// System set that runs in the [First] schedule, for the systems that create the
+/// RatatuiCameraWidget components each frame, retrieve rendered images from the GPU, and keep the
+/// mechanisms for performing that retrieval up-to-date (e.g. after resizes).
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RatatuiCameraSet;

--- a/src/camera_readback.rs
+++ b/src/camera_readback.rs
@@ -35,8 +35,8 @@ impl Plugin for RatatuiCameraReadbackPlugin {
             First,
             (
                 create_ratatui_camera_widgets_system,
+                handle_camera_targeting_events_system,
                 (
-                    handle_camera_targeting_events_system,
                     update_ratatui_camera_readback_system,
                     update_ratatui_edge_detection_readback_system,
                     receive_camera_images_system,

--- a/src/camera_readback.rs
+++ b/src/camera_readback.rs
@@ -10,8 +10,8 @@ use bevy::{
 };
 
 use crate::{
-    RatatuiCamera, RatatuiCameraEdgeDetection, RatatuiCameraStrategy, RatatuiCameraWidget,
-    RatatuiSubcamera,
+    RatatuiCamera, RatatuiCameraEdgeDetection, RatatuiCameraSet, RatatuiCameraStrategy,
+    RatatuiCameraWidget, RatatuiSubcamera,
     camera_image_pipe::{
         ImageReceiver, ImageSender, create_image_pipe, receive_image, send_image_buffer,
     },
@@ -34,16 +34,17 @@ impl Plugin for RatatuiCameraReadbackPlugin {
         .add_systems(
             First,
             (
-                handle_camera_targeting_events_system,
+                create_ratatui_camera_widgets_system,
                 (
+                    handle_camera_targeting_events_system,
                     update_ratatui_camera_readback_system,
                     update_ratatui_edge_detection_readback_system,
                     receive_camera_images_system,
                     receive_sobel_images_system,
                 ),
-                create_ratatui_camera_widgets_system,
             )
-                .chain(),
+                .chain()
+                .in_set(RatatuiCameraSet),
         );
 
         let render_app = app.sub_app_mut(RenderApp);

--- a/src/camera_strategy.rs
+++ b/src/camera_strategy.rs
@@ -1,0 +1,122 @@
+use bevy::prelude::*;
+
+/// Specify the strategy used for converting the camera's rendered image to unicode characters for
+/// the terminal buffer. Insert a variant of this component alongside your `RatatuiCamera` to
+/// change the default behavior.
+///
+#[derive(Component, Clone, Debug, Default)]
+pub enum RatatuiCameraStrategy {
+    /// Print to the terminal using unicode halfblock characters. By using both the halfblock
+    /// (foreground) color and the background color, we can draw two pixels per buffer cell.
+    #[default]
+    HalfBlocks,
+
+    /// Given a range of unicode characters sorted in increasing order of opacity, use each pixel's
+    /// luminance to select a character from the range.
+    Luminance(LuminanceConfig),
+
+    /// Does not print characters by itself, but edge detection will still print. Use with edge
+    /// detection for a "wireframe".
+    None,
+}
+
+impl RatatuiCameraStrategy {
+    /// Luminance strategy with a range of braille unicode characters in increasing order of opacity.
+    pub fn luminance_braille() -> Self {
+        Self::Luminance(LuminanceConfig {
+            luminance_characters: LuminanceConfig::LUMINANCE_CHARACTERS_BRAILLE.into(),
+            ..default()
+        })
+    }
+
+    /// Luminance strategy with a range of miscellaneous characters in increasing order of opacity.
+    pub fn luminance_misc() -> Self {
+        Self::Luminance(LuminanceConfig {
+            luminance_characters: LuminanceConfig::LUMINANCE_CHARACTERS_MISC.into(),
+            ..default()
+        })
+    }
+
+    /// Luminance strategy with a range of block characters in increasing order of opacity.
+    pub fn luminance_shading() -> Self {
+        Self::Luminance(LuminanceConfig {
+            luminance_characters: LuminanceConfig::LUMINANCE_CHARACTERS_SHADING.into(),
+            ..default()
+        })
+    }
+}
+
+/// Configuration for the RatatuiCameraStrategy::Luminance terminal rendering strategy.
+///
+/// # Example:
+///
+/// The following would configure the widget to multiply each pixel's luminance value by 5.0, use
+/// ' ' and '.' for dimmer areas, use '+' and '#' for brighter areas, and skip using a mask color:
+///
+/// ```no_run
+/// # use bevy::prelude::*;
+/// # use bevy_ratatui_camera::{RatatuiCamera, RatatuiCameraStrategy, LuminanceConfig};
+/// #
+/// # fn setup_scene_system(mut commands: Commands) {
+/// # commands.spawn((
+/// #     RatatuiCamera::default(),
+///     RatatuiCameraStrategy::Luminance(LuminanceConfig {
+///         luminance_characters: vec![' ', '.', '+', '#'],
+///         luminance_scale: 5.0,
+///         mask_color: None,
+///     }),
+/// # ));
+/// # };
+/// ```
+///
+#[derive(Clone, Debug)]
+pub struct LuminanceConfig {
+    /// The list of characters, in increasing order of opacity, to use for printing. For example,
+    /// put an '@' symbol after a '+' symbol because it is more "opaque", taking up more space in
+    /// the cell it is printed in, and so when printed in bright text on a dark background, it
+    /// appears to be "brighter".
+    pub luminance_characters: Vec<char>,
+
+    /// The number that each luminance value is multiplied by before being used to select
+    /// a character. Because most scenes do not occupy the full range of luminance between 0.0 and
+    /// 1.0, each luminance value is multiplied by a scaling value first.
+    pub luminance_scale: f32,
+
+    /// An optional mask color for creating transparency effects. Skips writing any character to
+    /// the terminal buffer that matches the provided color.
+    ///
+    /// For example, set it to `Some(Color::Rgb(0, 0, 0)` in a scene with a foreground object in
+    /// front of a black background, to render that object without the background space overwriting
+    /// the cells currently in the buffer.
+    ///
+    /// Useful for compositing together multiple rendered layers. There should generally always be
+    /// at least one non-masked layer furthest back, as otherwise stray cells in the terminal
+    /// buffer might not get replaced between frames.
+    pub mask_color: Option<ratatui::style::Color>,
+}
+
+impl LuminanceConfig {
+    /// A range of braille unicode characters in increasing order of opacity.
+    pub const LUMINANCE_CHARACTERS_BRAILLE: &'static [char] =
+        &[' ', '⠂', '⠒', '⠖', '⠶', '⠷', '⠿', '⡿', '⣿'];
+
+    /// A range of miscellaneous characters in increasing order of opacity.
+    pub const LUMINANCE_CHARACTERS_MISC: &'static [char] =
+        &[' ', '.', ':', '+', '=', '!', '*', '?', '#', '%', '&', '@'];
+
+    /// A range of block characters in increasing order of opacity.
+    pub const LUMINANCE_CHARACTERS_SHADING: &'static [char] = &[' ', '░', '▒', '▓', '█'];
+
+    /// The default scaling value to multiply pixel luminance by.
+    const LUMINANCE_SCALE_DEFAULT: f32 = 10.;
+}
+
+impl Default for LuminanceConfig {
+    fn default() -> Self {
+        Self {
+            luminance_characters: LuminanceConfig::LUMINANCE_CHARACTERS_BRAILLE.into(),
+            luminance_scale: LuminanceConfig::LUMINANCE_SCALE_DEFAULT,
+            mask_color: None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,15 @@ mod camera_image_pipe;
 mod camera_node;
 mod camera_node_sobel;
 mod camera_readback;
+mod camera_strategy;
 mod plugin;
 mod widget;
 mod widget_halfblocks;
 mod widget_luminance;
 mod widget_none;
 
-pub use camera::{LuminanceConfig, RatatuiCamera, RatatuiCameraStrategy, RatatuiSubcamera};
+pub use camera::{RatatuiCamera, RatatuiCameraSet, RatatuiSubcamera};
 pub use camera_edge_detection::{EdgeCharacters, RatatuiCameraEdgeDetection};
+pub use camera_strategy::{LuminanceConfig, RatatuiCameraStrategy};
 pub use plugin::RatatuiCameraPlugin;
 pub use widget::RatatuiCameraWidget;


### PR DESCRIPTION
New system set that runs in the `First` update loop schedule that contains the main world systems. Useful for situations where a user might need to add a system in `First` but needs certain components from this crate to be available and correctly updated.

Also added a "dynamic_config" example meant to test the effect of inserting, changing, and removing config components (RatatuiCameraStrategy, RatatuiCameraEdgeDetection) on-the-fly.