### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.10.0...v0.11.0) - 2025-03-20
+
+### Other
+
+- mask on alpha instead of color
+- insert/update/remove user-facing components example
+- added a system set for First schedule systems
+
 ## [0.10.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.9.0...v0.10.0) - 2025-03-02
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ratatui_camera"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bevy",
  "bevy_mod_debugdump",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui_camera"
 description = "A bevy plugin for rendering your bevy app to the terminal using ratatui."
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 authors = ["cxreiff <cooper@cxreiff.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `bevy_ratatui_camera`: 0.10.0 -> 0.11.0 (⚠ API breaking changes)

### ⚠ `bevy_ratatui_camera` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field LuminanceConfig.transparent in /tmp/.tmpxSoYxO/bevy_ratatui_camera/src/camera_strategy.rs:96

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field mask_color of struct LuminanceConfig, previously in file /tmp/.tmpAQhosx/bevy_ratatui_camera/src/camera.rs:169
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.10.0...v0.11.0) - 2025-03-20

### Other

- mask on alpha instead of color
- insert/update/remove user-facing components example
- added a system set for First schedule systems
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).