### PR TITLE
Mask on alpha instead of color.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,12 +2131,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3834,18 +3834,18 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
+checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
 dependencies = [
  "profiling-procmacros",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
+checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
  "syn",
@@ -4179,15 +4179,15 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 Bevy inside the terminal!
 
 Uses bevy headless rendering,
-[ratatui](https://github.com/ratatui-org/ratatui), and
-[ratatui_image](https://github.com/benjajaja/ratatui-image) to print your bevy
+[ratatui](https://github.com/ratatui-org/ratatui),
+[ratatui_image](https://github.com/benjajaja/ratatui-image), and
+[bevy_ratatui](https://github.com/cxreiff/bevy_ratatui) to print your bevy
 application's rendered frames to the terminal.
 
 <p float="left">
@@ -15,9 +16,9 @@ application's rendered frames to the terminal.
 
 > examples/cube.rs, bevy many_foxes example, sponza test scene
 
-Use [bevy_ratatui](https://github.com/joshka/bevy_ratatui/tree/main) for
-setting ratatui up and receiving terminal events (keyboard, focus, mouse,
-paste, resize) inside bevy.
+Use [bevy_ratatui](https://github.com/cxreiff/bevy_ratatui) for setting ratatui
+up and receiving terminal events (keyboard, focus, mouse, paste, resize) inside
+bevy.
 
 > [!IMPORTANT]  
 > This crate was renamed from `bevy_ratatui_render` to `bevy_ratatui_camera`.

--- a/examples/transparency.rs
+++ b/examples/transparency.rs
@@ -11,7 +11,6 @@ use bevy_ratatui::RatatuiPlugins;
 use bevy_ratatui::kitty::KittyEnabled;
 use bevy_ratatui::terminal::RatatuiContext;
 use bevy_ratatui_camera::EdgeCharacters;
-use bevy_ratatui_camera::LuminanceConfig;
 use bevy_ratatui_camera::RatatuiCamera;
 use bevy_ratatui_camera::RatatuiCameraEdgeDetection;
 use bevy_ratatui_camera::RatatuiCameraPlugin;
@@ -34,7 +33,7 @@ fn main() {
         ))
         .init_resource::<shared::Flags>()
         .init_resource::<shared::InputState>()
-        .insert_resource(ClearColor(Color::BLACK))
+        .insert_resource(ClearColor(Color::srgba(0., 0., 0., 0.)))
         .add_systems(Startup, setup_scene_system)
         .add_systems(Update, draw_scene_system.map(error))
         .add_systems(PreUpdate, shared::handle_input_system)
@@ -58,22 +57,30 @@ fn setup_scene_system(
     commands.spawn((
         Foreground,
         RatatuiCamera::default(),
-        RatatuiCameraStrategy::Luminance(LuminanceConfig {
-            mask_color: Some(ratatui::style::Color::Rgb(0, 0, 0)),
-            ..default()
-        }),
+        RatatuiCameraStrategy::luminance_braille(),
         RatatuiCameraEdgeDetection {
-            edge_color: Some(ratatui::style::Color::Rgb(255, 0, 255)),
+            edge_color: Some(ratatui::style::Color::Magenta),
             edge_characters: EdgeCharacters::Single('#'),
             ..Default::default()
         },
         Camera3d::default(),
+        Camera {
+            // by setting this camera's clear_color transparent, background pixels will be given an
+            // alpha value of zero and so will be skipped when the ratatui buffer is drawn
+            clear_color: ClearColorConfig::Custom(Color::srgba(0., 0., 0., 0.)),
+            ..default()
+        },
         Transform::from_xyz(6., 0., 2.).looking_at(Vec3::ZERO, Vec3::Z),
     ));
     commands.spawn((
         Background,
         RatatuiCamera::default(),
         RatatuiCameraStrategy::luminance_misc(),
+        RatatuiCameraEdgeDetection {
+            edge_color: Some(ratatui::style::Color::Cyan),
+            edge_characters: EdgeCharacters::Single('#'),
+            ..Default::default()
+        },
         Camera3d::default(),
         Transform::from_xyz(3., 0., 1.).looking_at(Vec3::ZERO, Vec3::Z),
     ));

--- a/src/camera_strategy.rs
+++ b/src/camera_strategy.rs
@@ -51,7 +51,7 @@ impl RatatuiCameraStrategy {
 /// # Example:
 ///
 /// The following would configure the widget to multiply each pixel's luminance value by 5.0, use
-/// ' ' and '.' for dimmer areas, use '+' and '#' for brighter areas, and skip using a mask color:
+/// ' ' and '.' for dimmer areas, use '+' and '#' for brighter areas, and skip transparent pixels.
 ///
 /// ```no_run
 /// # use bevy::prelude::*;
@@ -63,7 +63,7 @@ impl RatatuiCameraStrategy {
 ///     RatatuiCameraStrategy::Luminance(LuminanceConfig {
 ///         luminance_characters: vec![' ', '.', '+', '#'],
 ///         luminance_scale: 5.0,
-///         mask_color: None,
+///         transparent: true,
 ///     }),
 /// # ));
 /// # };
@@ -82,17 +82,18 @@ pub struct LuminanceConfig {
     /// 1.0, each luminance value is multiplied by a scaling value first.
     pub luminance_scale: f32,
 
-    /// An optional mask color for creating transparency effects. Skips writing any character to
-    /// the terminal buffer that matches the provided color.
+    /// If the alpha value of a rendered pixel is zero, skip writing that character to the ratatui
+    /// buffer. Useful for compositing camera images together.
     ///
-    /// For example, set it to `Some(Color::Rgb(0, 0, 0)` in a scene with a foreground object in
-    /// front of a black background, to render that object without the background space overwriting
-    /// the cells currently in the buffer.
+    /// Normally if two camera widgets are rendered in the same buffer area, the first image will
+    /// be completely overwritten by the background of the second, even if the background is empty.
+    /// But, with this option enabled, transparent pixels in the second image will skip being drawn
+    /// and will leave the first layer as-is.
     ///
-    /// Useful for compositing together multiple rendered layers. There should generally always be
-    /// at least one non-masked layer furthest back, as otherwise stray cells in the terminal
-    /// buffer might not get replaced between frames.
-    pub mask_color: Option<ratatui::style::Color>,
+    /// Make sure to set the `Camera` component's `clear_color` to fully transparent for your
+    /// transparent camera entity. Only fully transparent pixels will be skipped. See the
+    /// `transparency` example for more detail.
+    pub transparent: bool,
 }
 
 impl LuminanceConfig {
@@ -116,7 +117,7 @@ impl Default for LuminanceConfig {
         Self {
             luminance_characters: LuminanceConfig::LUMINANCE_CHARACTERS_BRAILLE.into(),
             luminance_scale: LuminanceConfig::LUMINANCE_SCALE_DEFAULT,
-            mask_color: None,
+            transparent: true,
         }
     }
 }


### PR DESCRIPTION
I implemented the "masking" feature by having the user supply a masking color, but this caused the same problem as actual physical green screening (false positives). By rearranging the character conversion strategy to keep the alpha value for each pixel longer, we can skip drawing characters to the buffer based on the pixel transparency instead of a specific color.

By setting the `clear_color` of a camera to a fully transparent color, that camera can be layered on top of other cameras, which is more straightforward and won't require actively avoiding your masking color.