### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.11.1...v0.12.0) - 2025-04-03
+
+### Fixed
+
+- saturating add causing washed out colors
+
+### Other
+
+- deduped some widget code into widget_utilities
+- replaced ratatui-image with HalfBlocks strategy
+- luminance_characters(), bg_color_scale
+
 ## [0.11.1](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.11.0...v0.11.1) - 2025-03-26
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ratatui_camera"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "bevy",
  "bevy_mod_debugdump",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui_camera"
 description = "A bevy plugin for rendering your bevy app to the terminal using ratatui."
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cxreiff/bevy_ratatui_camera"

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ depend on the terminal and on user configuration.
 
 | bevy  | bevy_ratatui_camera |
 |-------|---------------------|
-| 0.15  | 0.11                |
+| 0.15  | 0.12                |
 | 0.14  | 0.6                 |
 
 [Crate]: https://crates.io/crates/bevy_ratatui_camera


### PR DESCRIPTION



## 🤖 New release

* `bevy_ratatui_camera`: 0.11.1 -> 0.12.0 (⚠ API breaking changes)

### ⚠ `bevy_ratatui_camera` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field LuminanceConfig.bg_color_scale in /tmp/.tmptTbrOt/bevy_ratatui_camera/src/camera_strategy.rs:185

--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant RatatuiCameraStrategy::HalfBlocks in /tmp/.tmptTbrOt/bevy_ratatui_camera/src/camera_strategy.rs:13
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.11.1...v0.12.0) - 2025-04-03

### Fixed

- saturating add causing washed out colors

### Other

- deduped some widget code into widget_utilities
- replaced ratatui-image with HalfBlocks strategy
- luminance_characters(), bg_color_scale
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).