### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.12.0...v0.13.0) - 2025-04-27
+
+### Other
+
+- doc fix for subcameras
+- smoothed FPS counter
+- bevy 0.16 migration
+
 ## [0.12.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.11.1...v0.12.0) - 2025-04-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ratatui_camera"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bevy",
  "bevy_ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui_camera"
 description = "A bevy plugin for rendering your bevy app to the terminal using ratatui."
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cxreiff/bevy_ratatui_camera"


### PR DESCRIPTION



## 🤖 New release

* `bevy_ratatui_camera`: 0.12.0 -> 0.13.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.12.0...v0.13.0) - 2025-04-27

### Other

- doc fix for subcameras
- smoothed FPS counter
- bevy 0.16 migration
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).