### PR TITLE
NDC and cell coordinate conversion math

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ fn setup_scene_system(mut commands: Commands) {
 // a RatatuiCameraWidget component will be available in your camera entity.
 fn draw_scene_system(
     mut ratatui: ResMut<RatatuiContext>,
-    camera_widget: Single<&RatatuiCameraWidget>,
+    mut camera_widget: Single<&mut RatatuiCameraWidget>,
 ) -> Result {
     ratatui.draw(|frame| {
         camera_widget.render(frame.area(), frame.buffer_mut());
@@ -100,21 +100,20 @@ commands.spawn((
 
 ## autoresize
 
-By default, the size of the texture the camera renders to will stay constant,
-and when rendered to the ratatui buffer with `RatatuiCameraWidget::render(...)`
-it will retain its aspect ratio. If you use the
-`RatatuiCameraWidget::render_autoresize` variant instead, whenever the render
-texture doesn't match the size of the render area, rendering will be skipped
-that frame and a resize of the render texture will be triggered instead.
+By default, the dimensions of the texture the camera renders to will be resized
+each frame to the dimensions and aspect ratio of the buffer area it was last
+rendered within, to gracefully handle any changes in the window size or your
+ratatui layout. If you would like to keep a fixed size and aspect ratio
+instead, set `dimensions`, set the `autoresize` attribute inside
+`RatatuiCamera` to false (or use `RatatuiCamera::new(width: u32, height: u32)`
+to do both). Your supplied width and height will be used to create the render
+texture and when rendered to the ratatui buffer with
+`RatatuiCameraWidget::render(...)` it will retain its aspect ratio.
 
 ```rust
-ratatui.draw(|frame| {
-    camera_widget.render_autoresize(
-        frame.area(),
-        frame.buffer_mut(),
-        &mut commands,
-    );
-})?;
+commands.spawn((
+    RatatuiCamera::new(800, 600),
+));
 ```
 
 ## edge detection

--- a/examples/2d_camera.rs
+++ b/examples/2d_camera.rs
@@ -13,6 +13,7 @@ use bevy_ratatui_camera::RatatuiCameraPlugin;
 use bevy_ratatui_camera::RatatuiCameraStrategy;
 use bevy_ratatui_camera::RatatuiCameraWidget;
 use log::LevelFilter;
+use ratatui::widgets::Widget;
 
 mod shared;
 
@@ -58,9 +59,8 @@ fn setup_scene_system(
 }
 
 fn draw_scene_system(
-    mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
-    camera_widget: Single<&RatatuiCameraWidget>,
+    mut camera_widget: Single<&mut RatatuiCameraWidget>,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,
@@ -68,7 +68,7 @@ fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        camera_widget.render_autoresize(area, frame.buffer_mut(), &mut commands);
+        camera_widget.render(area, frame.buffer_mut());
     })?;
 
     Ok(())

--- a/examples/3d_camera.rs
+++ b/examples/3d_camera.rs
@@ -37,7 +37,7 @@ fn main() {
         ))
         .init_resource::<shared::Flags>()
         .init_resource::<shared::InputState>()
-        .insert_resource(ClearColor(Color::WHITE))
+        .insert_resource(ClearColor(Color::BLACK))
         .add_systems(Startup, setup_scene_system)
         .add_systems(Update, draw_scene_system)
         .add_systems(PreUpdate, shared::handle_input_system)

--- a/examples/3d_camera.rs
+++ b/examples/3d_camera.rs
@@ -37,7 +37,7 @@ fn main() {
         ))
         .init_resource::<shared::Flags>()
         .init_resource::<shared::InputState>()
-        .insert_resource(ClearColor(Color::BLACK))
+        .insert_resource(ClearColor(Color::WHITE))
         .add_systems(Startup, setup_scene_system)
         .add_systems(Update, draw_scene_system)
         .add_systems(PreUpdate, shared::handle_input_system)
@@ -62,7 +62,7 @@ fn setup_scene_system(
 
 fn draw_scene_system(
     mut ratatui: ResMut<RatatuiContext>,
-    camera_widget: Single<&RatatuiCameraWidget>,
+    mut camera_widget: Single<&mut RatatuiCameraWidget>,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,

--- a/examples/color_support.rs
+++ b/examples/color_support.rs
@@ -17,6 +17,7 @@ use bevy_ratatui_camera::RatatuiCameraPlugin;
 use bevy_ratatui_camera::RatatuiCameraStrategy;
 use bevy_ratatui_camera::RatatuiCameraWidget;
 use log::LevelFilter;
+use ratatui::widgets::Widget;
 use shared::Spinner;
 
 mod shared;
@@ -68,9 +69,8 @@ fn setup_scene_system(
 }
 
 fn draw_scene_system(
-    mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
-    camera_widget: Single<&RatatuiCameraWidget>,
+    mut camera_widget: Single<&mut RatatuiCameraWidget>,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,
@@ -78,7 +78,7 @@ fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        camera_widget.render_autoresize(area, frame.buffer_mut(), &mut commands);
+        camera_widget.render(area, frame.buffer_mut());
     })?;
 
     Ok(())

--- a/examples/dynamic_config.rs
+++ b/examples/dynamic_config.rs
@@ -22,6 +22,7 @@ use bevy_ratatui_camera::RatatuiCameraWidget;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEventKind;
 use log::LevelFilter;
+use ratatui::widgets::Widget;
 
 mod shared;
 
@@ -68,9 +69,8 @@ fn setup_scene_system(
 }
 
 fn draw_scene_system(
-    mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
-    camera_widget: Single<&RatatuiCameraWidget>,
+    mut camera_widget: Single<&mut RatatuiCameraWidget>,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,
@@ -78,7 +78,7 @@ fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        camera_widget.render_autoresize(area, frame.buffer_mut(), &mut commands);
+        camera_widget.render(area, frame.buffer_mut());
     })?;
 
     Ok(())

--- a/examples/edge_detection.rs
+++ b/examples/edge_detection.rs
@@ -16,6 +16,7 @@ use bevy_ratatui_camera::RatatuiCameraPlugin;
 use bevy_ratatui_camera::RatatuiCameraStrategy;
 use bevy_ratatui_camera::RatatuiCameraWidget;
 use log::LevelFilter;
+use ratatui::widgets::Widget;
 
 mod shared;
 
@@ -63,9 +64,8 @@ fn setup_scene_system(
 }
 
 fn draw_scene_system(
-    mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
-    camera_widget: Single<&RatatuiCameraWidget>,
+    mut camera_widget: Single<&mut RatatuiCameraWidget>,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,
@@ -73,7 +73,7 @@ fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        camera_widget.render_autoresize(area, frame.buffer_mut(), &mut commands);
+        camera_widget.render(area, frame.buffer_mut());
     })?;
 
     Ok(())

--- a/examples/luminance.rs
+++ b/examples/luminance.rs
@@ -15,6 +15,7 @@ use bevy_ratatui_camera::RatatuiCameraPlugin;
 use bevy_ratatui_camera::RatatuiCameraStrategy;
 use bevy_ratatui_camera::RatatuiCameraWidget;
 use log::LevelFilter;
+use ratatui::widgets::Widget;
 
 mod shared;
 
@@ -61,9 +62,8 @@ fn setup_scene_system(
 }
 
 fn draw_scene_system(
-    mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
-    camera_widget: Single<&RatatuiCameraWidget>,
+    mut camera_widget: Single<&mut RatatuiCameraWidget>,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,
@@ -71,7 +71,7 @@ fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        camera_widget.render_autoresize(area, frame.buffer_mut(), &mut commands);
+        camera_widget.render(area, frame.buffer_mut());
     })?;
 
     Ok(())

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -18,6 +18,7 @@ use log::LevelFilter;
 use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
 use ratatui::layout::Layout;
+use ratatui::widgets::Widget;
 
 mod shared;
 
@@ -80,9 +81,8 @@ fn setup_scene_system(
 }
 
 fn draw_scene_system(
-    mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
-    camera_widgets: Query<&RatatuiCameraWidget>,
+    mut camera_widgets: Query<&mut RatatuiCameraWidget>,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,
@@ -90,7 +90,7 @@ fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        let widgets = camera_widgets.iter().enumerate().collect::<Vec<_>>();
+        let widgets = camera_widgets.iter_mut().enumerate().collect::<Vec<_>>();
 
         let layout = Layout::new(
             Direction::Horizontal,
@@ -98,8 +98,8 @@ fn draw_scene_system(
         )
         .split(area);
 
-        for (i, widget) in widgets {
-            widget.render_autoresize(layout[i], frame.buffer_mut(), &mut commands);
+        for (i, mut widget) in widgets {
+            widget.render(layout[i], frame.buffer_mut());
         }
     })?;
 

--- a/examples/orthographic.rs
+++ b/examples/orthographic.rs
@@ -15,6 +15,7 @@ use bevy_ratatui_camera::RatatuiCameraPlugin;
 use bevy_ratatui_camera::RatatuiCameraStrategy;
 use bevy_ratatui_camera::RatatuiCameraWidget;
 use log::LevelFilter;
+use ratatui::widgets::Widget;
 
 mod shared;
 
@@ -65,9 +66,8 @@ fn setup_scene_system(
 }
 
 fn draw_scene_system(
-    mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
-    camera_widget: Single<&RatatuiCameraWidget>,
+    mut camera_widget: Single<&mut RatatuiCameraWidget>,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,
@@ -75,7 +75,7 @@ fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        camera_widget.render_autoresize(area, frame.buffer_mut(), &mut commands);
+        camera_widget.render(area, frame.buffer_mut());
     })?;
 
     Ok(())

--- a/examples/shared/mod.rs
+++ b/examples/shared/mod.rs
@@ -46,10 +46,6 @@ pub fn spawn_3d_scene(
         })),
     ));
     commands.spawn((
-        Mesh3d(meshes.add(Cuboid::new(15., 15., 1.))),
-        Transform::from_xyz(0., 0., -6.),
-    ));
-    commands.spawn((
         PointLight {
             intensity: 2_000_000.,
             shadows_enabled: true,

--- a/examples/subcamera.rs
+++ b/examples/subcamera.rs
@@ -14,6 +14,7 @@ use bevy_ratatui_camera::RatatuiCameraPlugin;
 use bevy_ratatui_camera::RatatuiCameraWidget;
 use bevy_ratatui_camera::RatatuiSubcameras;
 use log::LevelFilter;
+use ratatui::widgets::Widget;
 
 mod shared;
 
@@ -65,9 +66,8 @@ fn setup_scene_system(
 }
 
 fn draw_scene_system(
-    mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
-    camera_widget: Single<&RatatuiCameraWidget>,
+    mut camera_widget: Single<&mut RatatuiCameraWidget>,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,
@@ -75,7 +75,7 @@ fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        camera_widget.render_autoresize(area, frame.buffer_mut(), &mut commands);
+        camera_widget.render(area, frame.buffer_mut());
     })?;
 
     Ok(())

--- a/examples/text_labels.rs
+++ b/examples/text_labels.rs
@@ -1,0 +1,226 @@
+use std::f32::consts::PI;
+use std::time::Duration;
+
+use bevy::app::ScheduleRunnerPlugin;
+use bevy::color::Color;
+use bevy::diagnostic::DiagnosticsStore;
+use bevy::diagnostic::FrameTimeDiagnosticsPlugin;
+use bevy::log::LogPlugin;
+use bevy::math::U16Vec2;
+use bevy::prelude::*;
+use bevy::winit::WinitPlugin;
+use bevy_ratatui::RatatuiPlugins;
+use bevy_ratatui::kitty::KittyEnabled;
+use bevy_ratatui::terminal::RatatuiContext;
+use bevy_ratatui_camera::RatatuiCamera;
+use bevy_ratatui_camera::RatatuiCameraOverlayWidget;
+use bevy_ratatui_camera::RatatuiCameraPlugin;
+use bevy_ratatui_camera::RatatuiCameraWidget;
+use log::LevelFilter;
+use ratatui::layout::Rect;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::widgets::Block;
+use ratatui::widgets::Widget;
+use ratatui::widgets::WidgetRef;
+use shared::Spinner;
+
+mod shared;
+
+fn main() {
+    shared::setup_tui_logger(LevelFilter::Info);
+
+    App::new()
+        .add_plugins((
+            DefaultPlugins
+                .build()
+                .disable::<WinitPlugin>()
+                .disable::<LogPlugin>(),
+            ScheduleRunnerPlugin::run_loop(Duration::from_secs_f64(1. / 60.)),
+            FrameTimeDiagnosticsPlugin {
+                smoothing_factor: 1.0,
+                ..default()
+            },
+            RatatuiPlugins::default(),
+            RatatuiCameraPlugin,
+        ))
+        .init_resource::<shared::Flags>()
+        .init_resource::<shared::InputState>()
+        .insert_resource(ClearColor(Color::BLACK))
+        .add_systems(Startup, (setup_scene_system, setup_labels_system).chain())
+        .add_systems(Update, draw_scene_system)
+        .add_systems(PreUpdate, shared::handle_input_system)
+        .add_systems(Update, shared::rotate_spinners_system)
+        .add_systems(Update, sphere_movement_system)
+        .run();
+}
+
+#[derive(Component, Clone, Debug, Default)]
+pub struct ConeMarker;
+
+#[derive(Component, Clone, Debug, Default)]
+#[require(Transform)]
+pub struct RatatuiTextLabel {
+    text: String,
+}
+
+impl RatatuiTextLabel {
+    fn new(text: &str) -> Self {
+        Self { text: text.into() }
+    }
+}
+
+#[derive(Debug)]
+pub struct RatatuiTextLabelWidget {
+    text: String,
+    anchor: RatatuiTextLabelWidgetAnchor,
+    x: u16,
+    y: u16,
+}
+
+#[derive(Debug)]
+enum RatatuiTextLabelWidgetAnchor {
+    Left,
+    Center,
+}
+
+impl WidgetRef for RatatuiTextLabelWidget {
+    fn render_ref(&self, area: ratatui::prelude::Rect, buf: &mut ratatui::prelude::Buffer) {
+        let mut width = self.text.len() as u16 + 4;
+        let height = 3;
+        let mut span = Line::from(format!(" {} ", self.text.clone()));
+
+        let x = if let RatatuiTextLabelWidgetAnchor::Center = self.anchor {
+            if width / 2 > self.x {
+                width = width / 2 + self.x;
+                span = span.right_aligned();
+            }
+
+            (area.x + self.x).saturating_sub(width / 2)
+        } else {
+            area.x + self.x
+        };
+
+        let x_adjusted = x.max(area.x);
+        let y_adjusted = (area.y + self.y).max(area.y);
+        let width_adjusted = width.min(area.x + area.width.saturating_sub(x_adjusted));
+        let height_adjusted = height.min(area.y + area.height.saturating_sub(y_adjusted));
+
+        let label_area = Rect {
+            x: x_adjusted,
+            y: y_adjusted,
+            width: width_adjusted,
+            height: height_adjusted,
+        };
+
+        let block = Block::bordered()
+            .fg(ratatui::style::Color::Green)
+            .bg(ratatui::style::Color::Black);
+
+        span.render(block.inner(label_area), buf);
+        block.render(label_area, buf);
+    }
+}
+
+impl RatatuiCameraOverlayWidget for RatatuiTextLabelWidget {}
+
+fn setup_scene_system(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands.spawn((
+        ConeMarker,
+        Mesh3d(meshes.add(Cone::new(0.5, 1.))),
+        MeshMaterial3d(materials.add(Color::srgb(1., 0., 0.))),
+        Transform::from_rotation(Quat::from_rotation_x(PI / 2.)),
+    ));
+
+    shared::spawn_3d_scene(commands.reborrow(), meshes, materials);
+
+    commands.spawn((
+        RatatuiCamera::default(),
+        Camera3d::default(),
+        Transform::from_xyz(2.5, 2.5, 2.5).looking_at(Vec3::ZERO, Vec3::Z),
+    ));
+}
+
+fn setup_labels_system(
+    mut commands: Commands,
+    cube: Single<Entity, With<Spinner>>,
+    cone: Single<Entity, With<ConeMarker>>,
+) {
+    commands
+        .entity(*cube)
+        .with_child((RatatuiTextLabel::new("cube"),));
+    commands
+        .entity(*cone)
+        .with_child((RatatuiTextLabel::new("cone"),));
+}
+
+fn sphere_movement_system(
+    mut cube: Single<&mut Transform, With<Spinner>>,
+    mut cone: Single<&mut Transform, (With<ConeMarker>, Without<Spinner>)>,
+    time: Res<Time>,
+) {
+    let elapsed = time.elapsed_secs() * 0.5;
+    let elapsed_plus_pi = elapsed + PI;
+    cube.translation = Vec3::new(elapsed.sin(), elapsed.cos(), 0.);
+    cone.translation = Vec3::new(elapsed_plus_pi.sin(), elapsed_plus_pi.cos(), 0.);
+}
+
+fn draw_scene_system(
+    mut ratatui: ResMut<RatatuiContext>,
+    mut ratatui_camera_single: Single<(&Camera, &GlobalTransform, &mut RatatuiCameraWidget)>,
+    labels: Query<(&RatatuiTextLabel, &GlobalTransform)>,
+    flags: Res<shared::Flags>,
+    diagnostics: Res<DiagnosticsStore>,
+    kitty_enabled: Option<Res<KittyEnabled>>,
+) -> Result {
+    let (camera, camera_transform, ref mut widget) = *ratatui_camera_single;
+
+    ratatui.draw(|frame| {
+        let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
+
+        let mut label_widgets = labels
+            .iter()
+            .filter_map(|(label, label_transform)| {
+                let anchor = RatatuiTextLabelWidgetAnchor::Center;
+                let ndc = camera.world_to_ndc(camera_transform, label_transform.translation())?;
+                let text = format!(
+                    "{}: {:.1}, {:.1}, {:.1}",
+                    label.text.clone(),
+                    ndc.x,
+                    ndc.y,
+                    ndc.z,
+                );
+                let U16Vec2 { x, y } = widget.ndc_to_cell(area, ndc);
+
+                let overlay_widget = RatatuiTextLabelWidget { text, anchor, x, y };
+
+                Some((overlay_widget, ndc.z))
+            })
+            .collect::<Vec<_>>();
+
+        label_widgets.sort_by(|(_, a), (_, b)| a.total_cmp(b).reverse());
+
+        while let Some((label_widget, _)) = label_widgets.pop() {
+            widget.push_overlay_widget(Box::new(label_widget));
+        }
+
+        widget.push_overlay_widget(Box::new(RatatuiTextLabelWidget {
+            text: format!(
+                "width: {}, height: {}",
+                frame.area().width,
+                frame.area().height
+            ),
+            x: 1,
+            y: 1,
+            anchor: RatatuiTextLabelWidgetAnchor::Left,
+        }));
+
+        widget.render(area, frame.buffer_mut());
+    })?;
+
+    Ok(())
+}

--- a/examples/transparency.rs
+++ b/examples/transparency.rs
@@ -15,6 +15,7 @@ use bevy_ratatui_camera::RatatuiCameraEdgeDetection;
 use bevy_ratatui_camera::RatatuiCameraPlugin;
 use bevy_ratatui_camera::RatatuiCameraStrategy;
 use bevy_ratatui_camera::RatatuiCameraWidget;
+use ratatui::widgets::Widget;
 
 mod shared;
 
@@ -89,10 +90,15 @@ fn setup_scene_system(
 }
 
 fn draw_scene_system(
-    mut commands: Commands,
     mut ratatui: ResMut<RatatuiContext>,
-    foreground_widget: Single<&RatatuiCameraWidget, With<Foreground>>,
-    background_widget: Single<&RatatuiCameraWidget, With<Background>>,
+    mut foreground_widget: Single<
+        &mut RatatuiCameraWidget,
+        (With<Foreground>, Without<Background>),
+    >,
+    mut background_widget: Single<
+        &mut RatatuiCameraWidget,
+        (With<Background>, Without<Foreground>),
+    >,
     flags: Res<shared::Flags>,
     diagnostics: Res<DiagnosticsStore>,
     kitty_enabled: Option<Res<KittyEnabled>>,
@@ -100,8 +106,8 @@ fn draw_scene_system(
     ratatui.draw(|frame| {
         let area = shared::debug_frame(frame, &flags, &diagnostics, kitty_enabled.as_deref());
 
-        background_widget.render_autoresize(area, frame.buffer_mut(), &mut commands);
-        foreground_widget.render_autoresize(area, frame.buffer_mut(), &mut commands);
+        background_widget.render(area, frame.buffer_mut());
+        foreground_widget.render(area, frame.buffer_mut());
     })?;
 
     Ok(())

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use ratatui::layout::Rect;
 
 use crate::camera_strategy::RatatuiCameraStrategy;
 
@@ -20,26 +21,39 @@ use crate::camera_strategy::RatatuiCameraStrategy;
 /// ```
 ///
 #[derive(Component, Clone, Debug)]
-#[require(RatatuiCameraStrategy)]
+#[require(RatatuiCameraStrategy, RatatuiCameraLastArea)]
 pub struct RatatuiCamera {
+    /// Whether to automatically resize the render texture based on the previous area the
+    /// associated widget was rendered to.
+    pub autoresize: bool,
+
     /// Dimensions (width, height) of the image the camera will render to.
-    pub dimensions: (u32, u32),
+    pub dimensions: UVec2,
 }
 
 impl Default for RatatuiCamera {
     fn default() -> Self {
         Self {
-            dimensions: (256, 256),
+            autoresize: true,
+            dimensions: UVec2::new(1, 1),
         }
     }
 }
 
 impl RatatuiCamera {
     /// Creates a new RatatuiCamera that renders to an image of the provided dimensions.
-    pub fn new(dimensions: (u32, u32)) -> Self {
-        Self { dimensions }
+    pub fn new(width: u32, height: u32) -> Self {
+        Self {
+            autoresize: false,
+            dimensions: UVec2::new(width, height),
+        }
     }
 }
+
+/// Component representing the area that the camera entity's widget was rendered within last frame.
+/// Used internally for triggering resizes, and translating buffer coordinates to bevy coordinates.
+#[derive(Component, Deref, Clone, Debug, Default)]
+pub struct RatatuiCameraLastArea(pub Rect);
 
 /// Bevy relation that allows you to create subcameras that render to a main camera's render
 /// texture instead of creating their own. When `RatatuiSubcamera` is within into a camera entity

--- a/src/camera_image_pipe.rs
+++ b/src/camera_image_pipe.rs
@@ -28,7 +28,7 @@ pub struct ImageReceiver {
 pub fn create_image_pipe(
     images: &mut Assets<Image>,
     render_device: &RenderDevice,
-    dimensions: (u32, u32),
+    dimensions: UVec2,
 ) -> (ImageSender, ImageReceiver) {
     let (sender, receiver, buffer, sender_image, receiver_image) =
         create_image_copy_objects(render_device, images, dimensions);
@@ -50,7 +50,7 @@ pub fn create_image_pipe(
 fn create_image_copy_objects(
     render_device: &RenderDevice,
     images: &mut Assets<Image>,
-    dimensions: (u32, u32),
+    dimensions: UVec2,
 ) -> (
     Sender<Vec<u8>>,
     Receiver<Vec<u8>>,
@@ -66,11 +66,10 @@ fn create_image_copy_objects(
     (sender, receiver, buffer, sender_handle, receiver_texture)
 }
 
-fn create_image_copy_textures(dimensions: (u32, u32)) -> (Image, Image) {
-    let (width, height) = dimensions;
+fn create_image_copy_textures(dimensions: UVec2) -> (Image, Image) {
     let size = Extent3d {
-        width,
-        height,
+        width: dimensions.x,
+        height: dimensions.y,
         ..Default::default()
     };
 
@@ -90,11 +89,11 @@ fn create_image_copy_textures(dimensions: (u32, u32)) -> (Image, Image) {
     (sender_texture, receiver_texture)
 }
 
-fn create_image_copy_buffer(render_device: &RenderDevice, (width, height): (u32, u32)) -> Buffer {
-    let padded_bytes_per_row = RenderDevice::align_copy_bytes_per_row((width) as usize) * 4;
+fn create_image_copy_buffer(render_device: &RenderDevice, dimensions: UVec2) -> Buffer {
+    let padded_bytes_per_row = RenderDevice::align_copy_bytes_per_row((dimensions.x) as usize) * 4;
     let buffer_descriptor = BufferDescriptor {
         label: None,
-        size: padded_bytes_per_row as u64 * height as u64,
+        size: padded_bytes_per_row as u64 * dimensions.y as u64,
         usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
         mapped_at_creation: false,
     };

--- a/src/camera_node_sobel.rs
+++ b/src/camera_node_sobel.rs
@@ -197,10 +197,7 @@ fn prepare_config_buffer_system(
     for (entity_id, edge_detection) in &mut ratatui_cameras {
         let config = RatatuiCameraNodeSobelConfig::from(edge_detection);
 
-        let buffer = config_buffers
-            .buffers
-            .entry(*entity_id)
-            .or_insert(UniformBuffer::default());
+        let buffer = config_buffers.buffers.entry(*entity_id).or_default();
         buffer.set(config);
         buffer.write_buffer(&render_device, &render_queue);
     }

--- a/src/camera_readback.rs
+++ b/src/camera_readback.rs
@@ -246,7 +246,7 @@ fn create_ratatui_camera_widgets_system(
             strategy: strategy.clone(),
             edge_detection: edge_detection.cloned(),
             last_area: **last_area,
-            overlay_widgets: vec![],
+            next_last_area: **last_area,
         };
 
         entity.insert(widget);
@@ -260,13 +260,14 @@ fn resize_ratatui_camera_observer(
     mut ratatui_cameras: Query<&mut RatatuiCamera>,
 ) -> Result {
     let (widget, last_area) = widgets.get(trigger.target())?;
-    let new_last_area = widget.last_area;
 
     commands
         .entity(trigger.target())
-        .insert(RatatuiCameraLastArea(new_last_area));
+        .insert(RatatuiCameraLastArea(widget.next_last_area));
 
-    if last_area.width == new_last_area.width && last_area.height == new_last_area.height {
+    if last_area.width == widget.next_last_area.width
+        && last_area.height == widget.next_last_area.height
+    {
         return Ok(());
     }
 
@@ -276,8 +277,8 @@ fn resize_ratatui_camera_observer(
 
     let mut ratatui_camera = ratatui_cameras.get_mut(trigger.target())?;
     ratatui_camera.dimensions = UVec2::new(
-        (new_last_area.width as u32 * 2).max(1),
-        (new_last_area.height as u32 * 4).max(1),
+        (widget.next_last_area.width as u32 * 2).max(1),
+        (widget.next_last_area.height as u32 * 4).max(1),
     );
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 //! Bevy rendered to the terminal!
 
 mod camera;
-// mod camera_cell_ray;
 mod camera_edge_detection;
 mod camera_image_pipe;
 mod camera_node;
@@ -26,4 +25,4 @@ pub use camera_edge_detection::{EdgeCharacters, RatatuiCameraEdgeDetection};
 pub use camera_strategy::{HalfBlocksConfig, LuminanceConfig, RatatuiCameraStrategy};
 pub use color_support::ColorSupport;
 pub use plugin::RatatuiCameraPlugin;
-pub use widget::{RatatuiCameraOverlayWidget, RatatuiCameraWidget};
+pub use widget::RatatuiCameraWidget;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! Bevy rendered to the terminal!
 
 mod camera;
+// mod camera_cell_ray;
 mod camera_edge_detection;
 mod camera_image_pipe;
 mod camera_node;
@@ -12,14 +13,17 @@ mod camera_strategy;
 mod color_support;
 mod plugin;
 mod widget;
-mod widget_halfblocks;
-mod widget_luminance;
-mod widget_none;
+mod widget_math;
+mod widget_strategy_halfblocks;
+mod widget_strategy_luminance;
+mod widget_strategy_none;
 mod widget_utilities;
 
-pub use camera::{RatatuiCamera, RatatuiCameraSet, RatatuiSubcamera, RatatuiSubcameras};
+pub use camera::{
+    RatatuiCamera, RatatuiCameraLastArea, RatatuiCameraSet, RatatuiSubcamera, RatatuiSubcameras,
+};
 pub use camera_edge_detection::{EdgeCharacters, RatatuiCameraEdgeDetection};
 pub use camera_strategy::{HalfBlocksConfig, LuminanceConfig, RatatuiCameraStrategy};
 pub use color_support::ColorSupport;
 pub use plugin::RatatuiCameraPlugin;
-pub use widget::RatatuiCameraWidget;
+pub use widget::{RatatuiCameraOverlayWidget, RatatuiCameraWidget};

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -55,7 +55,7 @@ use crate::{
 /// // a RatatuiCameraWidget component will be available in your camera entity.
 /// fn draw_scene_system(
 ///     mut ratatui: ResMut<RatatuiContext>,
-///     camera_widget: Single<&RatatuiCameraWidget>,
+///     mut camera_widget: Single<&mut RatatuiCameraWidget>,
 /// ) -> Result {
 ///     ratatui.draw(|frame| {
 ///         camera_widget.render(frame.area(), frame.buffer_mut());

--- a/src/widget_math.rs
+++ b/src/widget_math.rs
@@ -1,0 +1,68 @@
+use bevy::math::{U16Vec2, Vec3};
+use image::{DynamicImage, imageops::FilterType};
+use ratatui::layout::Rect;
+
+use crate::RatatuiCameraWidget;
+
+impl RatatuiCameraWidget {
+    /// Calculate the aspect ratio of the widget's render image.
+    pub fn aspect_ratio(&self) -> f32 {
+        (self.camera_image.width() * 2) as f32 / self.camera_image.height() as f32
+    }
+
+    /// Calculate the area that the image will actually be drawn (excluding the vertical or
+    /// horizontal gutters needed to preserve the image aspect ratio).
+    pub fn calculate_render_area(&self, area: Rect) -> Rect {
+        let aspect_ratio = self.aspect_ratio();
+        let width = (area.width as f32)
+            .min(area.height as f32 * aspect_ratio)
+            .round() as u16;
+        let height = (area.height as f32)
+            .min(area.width as f32 / aspect_ratio)
+            .round() as u16;
+
+        let x = area.x + (area.width - width) / 2;
+        let y = area.y + (area.height - height) / 2;
+
+        Rect {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    /// Return the camera image and (if present) sobel texture, resized to fit the area parameter.
+    pub fn resize_images_to_area(&self, area: Rect) -> (DynamicImage, Option<DynamicImage>) {
+        let width = area.width as u32;
+        let height = area.height as u32 * 2;
+
+        let camera_image = self.camera_image.resize(width, height, FilterType::Nearest);
+
+        let sobel_image = self
+            .sobel_image
+            .as_ref()
+            .map(|i| i.resize(width, height, FilterType::Nearest));
+
+        (camera_image, sobel_image)
+    }
+
+    /// Convert a pair of terminal buffer cell coordinates (number of characters from the left edge
+    /// and top edge of the buffer, respectively) into an NDC (Normalized Device Coordinates) value
+    /// that represents a position in the camera viewport.
+    pub fn cell_to_ndc(&self, area: Rect, cell_coords: U16Vec2) -> Vec3 {
+        let x = ((cell_coords.x - area.x) as f32 / area.width as f32 - 0.5) * 2.;
+        let y = ((cell_coords.y - area.y) as f32 / area.height as f32 - 0.5) * -2.;
+        Vec3::new(x, y, 0.)
+    }
+
+    /// Convert an NDC (Normalized Device Coordinates) value that represents a position in the
+    /// camera viewport into a pair of terminal buffer cell coordinates (number of characters from
+    /// the left edge and top edge of the buffer, respectively).
+    pub fn ndc_to_cell(&self, area: Rect, ndc_coords: Vec3) -> U16Vec2 {
+        let render_area = self.calculate_render_area(area);
+        let x = ((ndc_coords.x / 2. + 0.5) * render_area.width as f32) as u16;
+        let y = ((-ndc_coords.y / 2. + 0.5) * render_area.height as f32) as u16;
+        U16Vec2 { x, y }
+    }
+}

--- a/src/widget_math.rs
+++ b/src/widget_math.rs
@@ -67,7 +67,7 @@ impl RatatuiCameraWidget {
         let x = (cell_coords.x as f32 / render_area.width as f32 - 0.5) * 2.;
         let y = (cell_coords.y as f32 / render_area.height as f32 - 0.5) * -2.;
 
-        Vec3::new(x, y, 0.)
+        Vec3::new(x, y, 0.5)
     }
 
     /// Convert an NDC (Normalized Device Coordinates) value that represents a position in the

--- a/src/widget_strategy_halfblocks.rs
+++ b/src/widget_strategy_halfblocks.rs
@@ -5,21 +5,19 @@ use ratatui::widgets::WidgetRef;
 use crate::RatatuiCameraEdgeDetection;
 use crate::camera_strategy::HalfBlocksConfig;
 use crate::color_support::color_for_color_support;
-use crate::widget_utilities::{
-    calculate_render_area, coords_from_index, replace_detected_edges, resize_image_to_area,
-};
+use crate::widget_utilities::{coords_from_index, replace_detected_edges};
 
 pub struct RatatuiCameraWidgetHalf<'a> {
-    camera_image: &'a DynamicImage,
-    sobel_image: &'a Option<DynamicImage>,
+    camera_image: DynamicImage,
+    sobel_image: Option<DynamicImage>,
     strategy_config: &'a HalfBlocksConfig,
     edge_detection: &'a Option<RatatuiCameraEdgeDetection>,
 }
 
 impl<'a> RatatuiCameraWidgetHalf<'a> {
     pub fn new(
-        camera_image: &'a DynamicImage,
-        sobel_image: &'a Option<DynamicImage>,
+        camera_image: DynamicImage,
+        sobel_image: Option<DynamicImage>,
         strategy_config: &'a HalfBlocksConfig,
         edge_detection: &'a Option<RatatuiCameraEdgeDetection>,
     ) -> Self {
@@ -41,25 +39,17 @@ impl WidgetRef for RatatuiCameraWidgetHalf<'_> {
             edge_detection,
         } = self;
 
-        let camera_image = resize_image_to_area(area, camera_image);
-
-        let render_area = calculate_render_area(area, &camera_image);
-
-        let cell_candidates = convert_image_to_cell_candidates(&camera_image, strategy_config);
-
-        let sobel_image = sobel_image
-            .as_ref()
-            .map(|sobel_image| resize_image_to_area(area, sobel_image));
+        let cell_candidates = convert_image_to_cell_candidates(camera_image, strategy_config);
 
         for (index, (mut bg, mut fg)) in cell_candidates.enumerate() {
             let mut character = '▄';
-            let (x, y) = coords_from_index(index, &camera_image);
+            let (x, y) = coords_from_index(index, camera_image);
 
-            if x >= render_area.width || y >= render_area.height {
+            if x >= area.width || y >= area.height {
                 continue;
             }
 
-            let Some(cell) = buf.cell_mut((render_area.x + x, render_area.y + y)) else {
+            let Some(cell) = buf.cell_mut((area.x + x, area.y + y)) else {
                 continue;
             };
 

--- a/src/widget_strategy_none.rs
+++ b/src/widget_strategy_none.rs
@@ -3,21 +3,18 @@ use ratatui::prelude::*;
 use ratatui::widgets::WidgetRef;
 
 use crate::RatatuiCameraEdgeDetection;
-use crate::widget_utilities::{
-    average_in_rgb, calculate_render_area, coords_from_index, replace_detected_edges,
-    resize_image_to_area,
-};
+use crate::widget_utilities::{average_in_rgb, coords_from_index, replace_detected_edges};
 
 pub struct RatatuiCameraWidgetNone<'a> {
-    camera_image: &'a DynamicImage,
-    sobel_image: &'a Option<DynamicImage>,
+    camera_image: DynamicImage,
+    sobel_image: Option<DynamicImage>,
     edge_detection: &'a Option<RatatuiCameraEdgeDetection>,
 }
 
 impl<'a> RatatuiCameraWidgetNone<'a> {
     pub fn new(
-        camera_image: &'a DynamicImage,
-        sobel_image: &'a Option<DynamicImage>,
+        camera_image: DynamicImage,
+        sobel_image: Option<DynamicImage>,
         edge_detection: &'a Option<RatatuiCameraEdgeDetection>,
     ) -> Self {
         Self {
@@ -40,19 +37,13 @@ impl WidgetRef for RatatuiCameraWidgetNone<'_> {
             return;
         };
 
-        let camera_image = resize_image_to_area(area, camera_image);
-
-        let render_area = calculate_render_area(area, &camera_image);
-
-        let mut color_characters = convert_image_to_colors(&camera_image);
-
-        let sobel_image = resize_image_to_area(area, sobel_image);
+        let mut color_characters = convert_image_to_colors(camera_image);
 
         for (index, color) in color_characters.iter_mut().enumerate() {
             let mut character = ' ';
-            let (x, y) = coords_from_index(index, &camera_image);
+            let (x, y) = coords_from_index(index, camera_image);
 
-            if x >= render_area.width || y >= render_area.height {
+            if x >= area.width || y >= area.height {
                 continue;
             }
 
@@ -65,7 +56,7 @@ impl WidgetRef for RatatuiCameraWidgetNone<'_> {
             (character, *color) =
                 replace_detected_edges(character, *color, &sobel_value, edge_detection);
 
-            if let Some(cell) = buf.cell_mut((render_area.x + x, render_area.y + y)) {
+            if let Some(cell) = buf.cell_mut((area.x + x, area.y + y)) {
                 cell.set_fg(*color).set_char(character);
             }
         }

--- a/src/widget_utilities.rs
+++ b/src/widget_utilities.rs
@@ -1,24 +1,7 @@
-use image::{DynamicImage, Rgb, Rgba, imageops::FilterType};
-use ratatui::{layout::Rect, style::Color};
+use image::{DynamicImage, Rgb, Rgba};
+use ratatui::style::Color;
 
 use crate::RatatuiCameraEdgeDetection;
-
-pub fn resize_image_to_area(area: Rect, image: &DynamicImage) -> DynamicImage {
-    image.resize(
-        area.width as u32,
-        area.height as u32 * 2,
-        FilterType::Nearest,
-    )
-}
-
-pub fn calculate_render_area(area: Rect, image: &DynamicImage) -> Rect {
-    Rect {
-        x: area.x + area.width.saturating_sub(image.width() as u16) / 2,
-        y: area.y + (area.height).saturating_sub(image.height() as u16 / 2) / 2,
-        width: image.width() as u16,
-        height: image.height() as u16 / 2,
-    }
-}
 
 pub fn coords_from_index(index: usize, image: &DynamicImage) -> (u16, u16) {
     (


### PR DESCRIPTION
- Added some utility functions for converting back and forth between NDC/clip-space and terminal buffer coordinates.
- Added function for rendering "overlay" widgets that use the same area as the camera widget.
- Added an example showing what NDC/cell conversion and overlay widgets are useful for:
   - aligning a normal ratatui widget with a `Transform` in a bevy game world.
   - aligning a bevy `Transform` with a cell coordinate pair (i.e. a mouse position over the terminal).
- Refactored autoresize to work automatically when camera widget is used as a normal Ratatui widget.