### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.13.0...v0.14.0) - 2025-05-13
+
+### Other
+
+- workflows fixed
+- bevy_ratatui version 0.9.0 bump
+- expanded `bg_color_scale` to custom color system
+- refactored depth detection to have less side effects
+- depth recording and widget occlusion example
+- successful depth readback and parsing, unutilized
+- extend text_labels example to show cell_to_ndc
+- cell-ndc conversion math and ergonomics fixes
+- refactored some area calculations, overlay widgets
+- reworked resizing to use Widget trait render
+
 ## [0.13.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.12.0...v0.13.0) - 2025-04-27
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ratatui_camera"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bevy",
  "bevy_ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui_camera"
 description = "A bevy plugin for rendering your bevy app to the terminal using ratatui."
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cxreiff/bevy_ratatui_camera"

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ depend on the terminal and on user configuration.
 
 | bevy  | bevy_ratatui_camera |
 |-------|---------------------|
-| 0.16  | 0.13                |
+| 0.16  | 0.14                |
 | 0.15  | 0.12                |
 | 0.14  | 0.6                 |
 


### PR DESCRIPTION



## 🤖 New release

* `bevy_ratatui_camera`: 0.13.0 -> 0.14.0 (⚠ API breaking changes)

### ⚠ `bevy_ratatui_camera` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type RatatuiCameraStrategy is no longer UnwindSafe, in /tmp/.tmpfWxG65/bevy_ratatui_camera/src/camera_strategy.rs:12
  type RatatuiCameraStrategy is no longer RefUnwindSafe, in /tmp/.tmpfWxG65/bevy_ratatui_camera/src/camera_strategy.rs:12
  type RatatuiCameraWidget is no longer UnwindSafe, in /tmp/.tmpfWxG65/bevy_ratatui_camera/src/widget.rs:20
  type RatatuiCameraWidget is no longer RefUnwindSafe, in /tmp/.tmpfWxG65/bevy_ratatui_camera/src/widget.rs:20
  type LuminanceConfig is no longer UnwindSafe, in /tmp/.tmpfWxG65/bevy_ratatui_camera/src/camera_strategy.rs:172
  type LuminanceConfig is no longer RefUnwindSafe, in /tmp/.tmpfWxG65/bevy_ratatui_camera/src/camera_strategy.rs:172

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RatatuiCamera.autoresize in /tmp/.tmpfWxG65/bevy_ratatui_camera/src/camera.rs:28
  field RatatuiCameraWidget.depth_image in /tmp/.tmpfWxG65/bevy_ratatui_camera/src/widget.rs:28
  field RatatuiCameraWidget.last_area in /tmp/.tmpfWxG65/bevy_ratatui_camera/src/widget.rs:40
  field LuminanceConfig.foreground_color in /tmp/.tmpfWxG65/bevy_ratatui_camera/src/camera_strategy.rs:185
  field LuminanceConfig.background_color in /tmp/.tmpfWxG65/bevy_ratatui_camera/src/camera_strategy.rs:188

--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field RatatuiCameraWidget.next_last_area in /tmp/.tmpfWxG65/bevy_ratatui_camera/src/widget.rs:44

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  RatatuiCameraWidget::resize, previously in file /tmp/.tmppb8B1D/bevy_ratatui_camera/src/widget.rs:75
  RatatuiCameraWidget::render_autoresize, previously in file /tmp/.tmppb8B1D/bevy_ratatui_camera/src/widget.rs:90

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  bevy_ratatui_camera::RatatuiCamera::new now takes 2 parameters instead of 1, in /tmp/.tmpfWxG65/bevy_ratatui_camera/src/camera.rs:45

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field ratatui_camera of struct RatatuiCameraWidget, previously in file /tmp/.tmppb8B1D/bevy_ratatui_camera/src/widget.rs:23
  field bg_color_scale of struct LuminanceConfig, previously in file /tmp/.tmppb8B1D/bevy_ratatui_camera/src/camera_strategy.rs:185
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.13.0...v0.14.0) - 2025-05-13

### Other

- workflows fixed
- bevy_ratatui version 0.9.0 bump
- expanded `bg_color_scale` to custom color system
- refactored depth detection to have less side effects
- depth recording and widget occlusion example
- successful depth readback and parsing, unutilized
- extend text_labels example to show cell_to_ndc
- cell-ndc conversion math and ergonomics fixes
- refactored some area calculations, overlay widgets
- reworked resizing to use Widget trait render
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).