### PR TITLE
chore: release v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.14.1...v0.14.2) - 2025-05-26
+
+### Other
+
+- crossterm feature not actually required
+
 ## [0.14.1](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.14.0...v0.14.1) - 2025-05-26
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ratatui_camera"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "bevy",
  "bevy_ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui_camera"
 description = "A bevy plugin for rendering your bevy app to the terminal using ratatui."
-version = "0.14.1"
+version = "0.14.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cxreiff/bevy_ratatui_camera"


### PR DESCRIPTION
## 🤖 New release

* `bevy_ratatui_camera`: 0.14.1 -> 0.14.2

Removed breaking change warning and version bump because it was for a feature that was added by a patch version one day prior, so impact is negligible.

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.2](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.14.1...v0.14.2) - 2025-05-26

### Other

- crossterm feature not actually required
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).