### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.14.2...v0.15.0) - 2025-05-31
+
+### Other
+
+- new depth strategy, refactored strategy config
+
 ## [0.14.2](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.14.1...v0.14.2) - 2025-05-26
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ratatui_camera"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "bevy",
  "bevy_ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui_camera"
 description = "A bevy plugin for rendering your bevy app to the terminal using ratatui."
-version = "0.14.2"
+version = "0.15.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cxreiff/bevy_ratatui_camera"

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ depend on the terminal and on user configuration.
 
 | bevy  | bevy_ratatui_camera |
 |-------|---------------------|
-| 0.16  | 0.14                |
+| 0.16  | 0.15                |
 | 0.15  | 0.12                |
 | 0.14  | 0.6                 |
 


### PR DESCRIPTION



## 🤖 New release

* `bevy_ratatui_camera`: 0.14.2 -> 0.15.0 (⚠ API breaking changes)

### ⚠ `bevy_ratatui_camera` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type HalfBlocksConfig is no longer UnwindSafe, in /tmp/.tmpx2ZhHx/bevy_ratatui_camera/src/camera_strategy.rs:200
  type HalfBlocksConfig is no longer RefUnwindSafe, in /tmp/.tmpx2ZhHx/bevy_ratatui_camera/src/camera_strategy.rs:200

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field HalfBlocksConfig.common in /tmp/.tmpx2ZhHx/bevy_ratatui_camera/src/camera_strategy.rs:202
  field HalfBlocksConfig.colors in /tmp/.tmpx2ZhHx/bevy_ratatui_camera/src/camera_strategy.rs:205
  field LuminanceConfig.common in /tmp/.tmpx2ZhHx/bevy_ratatui_camera/src/camera_strategy.rs:298
  field LuminanceConfig.characters in /tmp/.tmpx2ZhHx/bevy_ratatui_camera/src/camera_strategy.rs:301
  field LuminanceConfig.colors in /tmp/.tmpx2ZhHx/bevy_ratatui_camera/src/camera_strategy.rs:304

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant RatatuiCameraStrategy:Depth in /tmp/.tmpx2ZhHx/bevy_ratatui_camera/src/camera_strategy.rs:27

--- failure inherent_associated_pub_const_missing: inherent impl's associated pub const removed ---

Description:
An inherent impl's associated public constant is removed or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_associated_pub_const_missing.ron

Failed in:
  LuminanceConfig::LUMINANCE_CHARACTERS_BRAILLE, previously at /tmp/.tmpBxGmHD/bevy_ratatui_camera/src/camera_strategy.rs:199
  LuminanceConfig::LUMINANCE_CHARACTERS_MISC, previously at /tmp/.tmpBxGmHD/bevy_ratatui_camera/src/camera_strategy.rs:203
  LuminanceConfig::LUMINANCE_CHARACTERS_SHADING, previously at /tmp/.tmpBxGmHD/bevy_ratatui_camera/src/camera_strategy.rs:207
  LuminanceConfig::LUMINANCE_CHARACTERS_BLOCKS, previously at /tmp/.tmpBxGmHD/bevy_ratatui_camera/src/camera_strategy.rs:210

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field transparent of struct HalfBlocksConfig, previously in file /tmp/.tmpBxGmHD/bevy_ratatui_camera/src/camera_strategy.rs:116
  field color_support of struct HalfBlocksConfig, previously in file /tmp/.tmpBxGmHD/bevy_ratatui_camera/src/camera_strategy.rs:133
  field luminance_characters of struct LuminanceConfig, previously in file /tmp/.tmpBxGmHD/bevy_ratatui_camera/src/camera_strategy.rs:177
  field luminance_scale of struct LuminanceConfig, previously in file /tmp/.tmpBxGmHD/bevy_ratatui_camera/src/camera_strategy.rs:182
  field foreground_color of struct LuminanceConfig, previously in file /tmp/.tmpBxGmHD/bevy_ratatui_camera/src/camera_strategy.rs:185
  field background_color of struct LuminanceConfig, previously in file /tmp/.tmpBxGmHD/bevy_ratatui_camera/src/camera_strategy.rs:188
  field transparent of struct LuminanceConfig, previously in file /tmp/.tmpBxGmHD/bevy_ratatui_camera/src/camera_strategy.rs:191
  field color_support of struct LuminanceConfig, previously in file /tmp/.tmpBxGmHD/bevy_ratatui_camera/src/camera_strategy.rs:194
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.14.2...v0.15.0) - 2025-05-31

### Other

- new depth strategy, refactored strategy config
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).