### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.15.0...v0.16.0) - 2025-11-16
+
+### Other
+
+- bevy 0.17 migration
+
 ## [0.15.0](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.14.2...v0.15.0) - 2025-05-31
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ratatui_camera"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bevy",
  "bevy_ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui_camera"
 description = "A bevy plugin for rendering your bevy app to the terminal using ratatui."
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cxreiff/bevy_ratatui_camera"

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ depend on the terminal and on user configuration.
 
 | bevy  | bevy_ratatui_camera |
 |-------|---------------------|
+| 0.17  | 0.16                |
 | 0.16  | 0.15                |
 | 0.15  | 0.12                |
 | 0.14  | 0.6                 |


### PR DESCRIPTION



## 🤖 New release

* `bevy_ratatui_camera`: 0.15.0 -> 0.16.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.1](https://github.com/cxreiff/bevy_ratatui_camera/compare/v0.15.0...v0.16.0) - 2025-11-16

### Other

- bevy 0.17 migration
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).